### PR TITLE
Add team management dashboard and WakaTime integration

### DIFF
--- a/apps/vscode-cloud/Dockerfile
+++ b/apps/vscode-cloud/Dockerfile
@@ -51,7 +51,8 @@ RUN for ext in \
     formulahendry.code-runner \
     pkief.material-icon-theme \
     usernamehw.errorlens \
-    streetsidesoftware.code-spell-checker; \
+    streetsidesoftware.code-spell-checker \
+    WakaTime.vscode-wakatime; \
   do \
     code-server --install-extension "$ext" || echo "[docker] Warning: failed to install $ext"; \
   done

--- a/apps/vscode-cloud/Dockerfile
+++ b/apps/vscode-cloud/Dockerfile
@@ -1,9 +1,8 @@
 FROM codercom/code-server:ubuntu
 
-# Run as root to install system packages and configure FUSE
+# ── System packages (run as root) ─────────────────────────────────────────────
 USER root
 
-# Install tools + FUSE3 support
 RUN apt-get update && apt-get install -y \
     git \
     curl \
@@ -11,25 +10,51 @@ RUN apt-get update && apt-get install -y \
     vim \
     build-essential \
     fuse3 \
+    python3 \
+    python3-pip \
+    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
-# Install geesefs — an S3/R2-compatible FUSE filesystem with local caching and live sync
+# geesefs — S3/R2-compatible FUSE filesystem
 RUN curl -L https://github.com/yandex-cloud/geesefs/releases/latest/download/geesefs-linux-amd64 \
     -o /usr/local/bin/geesefs && chmod +x /usr/local/bin/geesefs
 
 # Allow non-root users to mount FUSE filesystems
 RUN echo "user_allow_other" >> /etc/fuse.conf
 
-# Install Node.js LTS
+# Node.js LTS (used by code-server and the CLI tools below)
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/*
 
-# Create workspace mount point owned by coder
+# ── AI coding CLIs ────────────────────────────────────────────────────────────
+# Installed globally so they are on PATH for every user and every terminal session.
+RUN npm install -g \
+    @anthropic-ai/claude-code \
+    @openai/codex
+
+# Workspace mount point
 RUN mkdir -p /home/coder/workspace && chown -R coder:coder /home/coder
 
-# Switch back to coder user
+# ── VS Code extensions (pre-installed at build time) ─────────────────────────
+# Installed from Open VSX Registry (code-server's default marketplace).
+# Failures are non-fatal — the IDE still launches without them.
 USER coder
+
+RUN for ext in \
+    eamodio.gitlens \
+    esbenp.prettier-vscode \
+    dbaeumer.vscode-eslint \
+    ms-python.python \
+    bradlc.vscode-tailwindcss \
+    christian-kohler.path-intellisense \
+    formulahendry.code-runner \
+    pkief.material-icon-theme \
+    usernamehw.errorlens \
+    streetsidesoftware.code-spell-checker; \
+  do \
+    code-server --install-extension "$ext" || echo "[docker] Warning: failed to install $ext"; \
+  done
 
 WORKDIR /home/coder
 

--- a/apps/vscode-cloud/README.md
+++ b/apps/vscode-cloud/README.md
@@ -1,6 +1,6 @@
 # vscode-cloud
 
-Per-user [code-server](https://github.com/coder/code-server) instances on Cloudflare Containers — one isolated VS Code environment per authenticated user, with workspace files persisted to R2 via FUSE and GitHub repos auto-cloned on first boot.
+Per-user [code-server](https://github.com/coder/code-server) instances on Cloudflare Containers — one isolated VS Code environment per authenticated user, with workspace files persisted to R2, GitHub repos auto-cloned on first boot, a team management dashboard, and WakaTime time tracking pre-installed.
 
 ## Architecture
 
@@ -8,154 +8,216 @@ Per-user [code-server](https://github.com/coder/code-server) instances on Cloudf
 Browser
   │
   ▼
-Worker (auth + routing)
+Worker  (auth + routing)
   ├─ CF Access JWT  ─────────┐
   ├─ Google OAuth session ───┤──▶ AuthUser { email, userId }
   └─ Dev mode header ────────┘
           │
-          ▼
-  Durable Object (per user, named by userId)
-    ├─ SQLite: password, userId
-    └─ Container (code-server on :8080)
-         ├─ geesefs FUSE → R2: users/{userId}/
-         └─ git clone → GITHUB_REPOS
+          ├─ /admin/*  ──▶  Teams handler  ──▶  D1  (teams / members / invites)
+          │
+          └─ /*  ──▶  Durable Object  (per user, named by userId)
+                          ├─ SQLite: userId → R2 prefix
+                          └─ Container  (code-server on :8080)
+                               ├─ geesefs FUSE → R2: users/{userId}/
+                               ├─ git clone → GITHUB_REPOS
+                               └─ ~/.wakatime.cfg  (if WAKATIME_API_KEY set)
 ```
 
 - **One Durable Object + Container per user** — fully isolated VS Code environments keyed by sanitised email.
-- **R2 workspace persistence** — geesefs mounts the R2 bucket at `/workspace` via FUSE; reads/writes sync automatically.
+- **Passwordless** — auth is enforced at the Worker layer (CF Access JWT or Google OAuth). `code-server` runs with `--auth none`; the container is never directly reachable.
+- **R2 workspace persistence** — [geesefs](https://github.com/yandex-cloud/geesefs) mounts the R2 bucket at `/home/coder/workspace` via FUSE; reads/writes sync automatically.
 - **GitHub repo auto-cloning** — set `GITHUB_REPOS` to clone repos into the workspace on container start.
-- **Two auth modes** — Cloudflare Access (enterprise) or Google OAuth (simpler setup), with dev-mode fallback.
-- **Secure random passwords** — 24-char base-62 string generated via Web Crypto on first boot, stored in DO SQLite.
-- **Idle cost control** — containers sleep after configurable inactivity (`SLEEP_AFTER`); `renewActivityTimeout()` keeps them alive while the browser tab is open.
+- **Teams dashboard** — create teams, invite members by email, manage roles, and see live container status per member.
+- **WakaTime time tracking** — extension pre-installed in every container; optionally auto-configured via `WAKATIME_API_KEY`.
+- **AI coding tools** — Claude Code and Codex CLIs installed globally; available in every terminal session.
+- **Idle cost control** — containers sleep after configurable inactivity (`SLEEP_AFTER`) and wake automatically on next request.
 
 ---
 
-## Quick start (dev mode)
+## Quick start
+
+### Prerequisites
+
+- [Node.js](https://nodejs.org) 18+
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) (`npm install -g wrangler`)
+- [Docker](https://docs.docker.com/get-docker/) (required to build the container image locally)
+- A Cloudflare account on the **Workers Paid** plan ($5/mo minimum)
+
+### 1. Install dependencies
 
 ```bash
+cd apps/vscode-cloud
 npm install
+```
+
+### 2. Log in to Cloudflare
+
+```bash
 wrangler login
+```
+
+### 3. Create cloud resources
+
+```bash
+# R2 bucket for workspace files (one shared bucket, per-user prefixes)
 wrangler r2 bucket create vscode-cloud-workspaces
+
+# D1 database for teams, members, and invites
+wrangler d1 create vscode-cloud-teams
+# → Copy the returned database_id into wrangler.jsonc → d1_databases[0].database_id
+
+# KV namespace for Google OAuth sessions (skip if using CF Access instead)
+wrangler kv namespace create SESSION_STORE
+# → Copy the returned id into wrangler.jsonc → kv_namespaces[0].id
+```
+
+### 4. Set secrets
+
+```bash
+# R2 API token — generate at dash.cloudflare.com → R2 → Manage R2 API tokens
+# Grant "Object Read & Write" on the vscode-cloud-workspaces bucket
+wrangler secret put R2_ACCESS_KEY_ID
+wrangler secret put R2_SECRET_ACCESS_KEY
+wrangler secret put R2_ACCOUNT_ID        # your Cloudflare account ID
+
+# Google OAuth client secret (only needed for Google OAuth auth)
+wrangler secret put GOOGLE_CLIENT_SECRET
+
+# GitHub PAT with repo scope (only needed for private repos in GITHUB_REPOS)
+wrangler secret put GITHUB_TOKEN
+```
+
+### 5. Configure `wrangler.jsonc`
+
+Open `wrangler.jsonc` and fill in the blanks:
+
+```jsonc
+"d1_databases": [{ "database_id": "<paste from step 3>" }],
+"kv_namespaces":  [{ "id":          "<paste from step 3>" }],
+
+"vars": {
+  "GOOGLE_CLIENT_ID": "<your-client-id>.apps.googleusercontent.com",
+  "ADMIN_EMAILS":     "you@example.com",          // platform-wide admin access
+  "WAKATIME_API_KEY": "",                          // optional — see WakaTime section
+  "GITHUB_REPOS":     "myorg/frontend,myorg/api", // optional
+  "SLEEP_AFTER":      "30m"
+}
+```
+
+### 6. Deploy
+
+```bash
 wrangler deploy
 ```
 
-With `TEAM_DOMAIN`, `POLICY_AUD`, and `GOOGLE_CLIENT_ID` all empty, auth falls back to the `x-user-id` header or `?user=` query param. **Local testing only.**
-
+The Worker URL is printed at the end:
 ```
-https://vscode-cloud.<your-subdomain>.workers.dev/setup?user=alice
+https://vscode-cloud.<your-subdomain>.workers.dev
 ```
-
-Copy the generated password, click **Open code-server**.
 
 ---
 
-## Auth option A — Cloudflare Access
+## Auth setup
 
-Best for teams already using Cloudflare One. Validates the `Cf-Access-Jwt-Assertion` JWT from Access.
+### Option A — Cloudflare Access (recommended for teams)
 
-### 1. Create an Access application
+Best if your organisation already uses Cloudflare One. CF Access validates the `Cf-Access-Jwt-Assertion` JWT before the request reaches the Worker.
 
-1. [Cloudflare One](https://one.dash.cloudflare.com/) → **Access** → **Applications** → **Add** → **Self-hosted**
-2. Set the domain to your Worker route (e.g. `code.example.com`)
-3. Add an Allow policy (e.g. emails in `@yourcompany.com`)
-4. Copy the **AUD tag** from the Basic information tab
-
-### 2. Configure
+1. Go to [Cloudflare One](https://one.dash.cloudflare.com/) → **Access** → **Applications** → **Add** → **Self-hosted**
+2. Set the application domain to your Worker URL (e.g. `code.example.com`)
+3. Add an **Allow** policy scoped to your team's emails or identity provider
+4. Copy the **AUD tag** from the application's Basic information tab
 
 ```jsonc
 // wrangler.jsonc
 "vars": {
   "TEAM_DOMAIN": "https://yourteam.cloudflareaccess.com",
-  "POLICY_AUD":  "your-aud-tag"
+  "POLICY_AUD":  "<aud-tag>"
 }
 ```
-
-### 3. Deploy
 
 ```bash
 wrangler deploy
 ```
 
----
+### Option B — Google OAuth
 
-## Auth option B — Google OAuth
+Simpler for public-facing deployments. Sessions are stored as 7-day KV entries.
 
-Simpler for public-facing apps. Stores 7-day sessions in KV.
-
-### 1. Create OAuth credentials
-
-[console.cloud.google.com](https://console.cloud.google.com) → APIs & Services → Credentials → **Create OAuth 2.0 Client ID**
-
-- Application type: **Web application**
-- Authorised redirect URI: `https://vscode-cloud.<subdomain>.workers.dev/auth/callback`
-
-### 2. Create the KV namespace
+1. Open [Google Cloud Console](https://console.cloud.google.com) → **APIs & Services** → **Credentials** → **Create OAuth 2.0 Client ID**
+2. Application type: **Web application**
+3. Authorised redirect URI: `https://vscode-cloud.<subdomain>.workers.dev/auth/callback`
+4. Copy the **Client ID** and **Client Secret**
 
 ```bash
+# Create the KV namespace (if not done in step 3 above)
 wrangler kv namespace create SESSION_STORE
 # Paste the returned id into wrangler.jsonc → kv_namespaces[0].id
-```
 
-### 3. Configure
+wrangler secret put GOOGLE_CLIENT_SECRET
+```
 
 ```jsonc
 // wrangler.jsonc
 "vars": {
-  "GOOGLE_CLIENT_ID": "your-client-id.apps.googleusercontent.com"
+  "GOOGLE_CLIENT_ID": "<client-id>.apps.googleusercontent.com"
 }
 ```
-
-```bash
-wrangler secret put GOOGLE_CLIENT_SECRET
-```
-
-### 4. Deploy
 
 ```bash
 wrangler deploy
 ```
 
-Users hit `/auth/login` to authenticate, then get their `/setup` password page.
+Users visit the landing page, click **Sign in with Google**, and land directly in their IDE.
+
+### Dev mode (no auth)
+
+Leave `TEAM_DOMAIN`, `POLICY_AUD`, and `GOOGLE_CLIENT_ID` all empty. The Worker accepts an `x-user-id` header or `?user=` query param. **Never use this in production.**
+
+```
+https://vscode-cloud.<subdomain>.workers.dev/?user=alice
+```
 
 ---
 
 ## R2 workspace persistence
 
-Each user's workspace lives at `users/{userId}/` inside the shared R2 bucket, FUSE-mounted at `/home/coder/workspace` via [geesefs](https://github.com/yandex-cloud/geesefs).
+Each user's workspace lives at `users/{userId}/` inside the shared R2 bucket, FUSE-mounted at `/home/coder/workspace` inside the container via geesefs.
 
-### Setup
+Without R2 credentials the container falls back to an ephemeral local workspace — files are lost when the container sleeps.
+
+### Generate an R2 API token
+
+1. [Cloudflare Dashboard](https://dash.cloudflare.com) → **R2** → **Manage R2 API tokens** → **Create API token**
+2. Permissions: **Object Read & Write**
+3. Scope: **Specific bucket** → `vscode-cloud-workspaces`
 
 ```bash
-# Create bucket
-wrangler r2 bucket create vscode-cloud-workspaces
-
-# Generate an R2 API token at dash.cloudflare.com → R2 → Manage R2 API tokens
-# Give it Object Read & Write on vscode-cloud-workspaces
-wrangler secret put R2_ACCESS_KEY_ID
-wrangler secret put R2_SECRET_ACCESS_KEY
-wrangler secret put R2_ACCOUNT_ID   # your Cloudflare account ID
+wrangler secret put R2_ACCESS_KEY_ID      # Token Access Key ID
+wrangler secret put R2_SECRET_ACCESS_KEY  # Token Secret Access Key
+wrangler secret put R2_ACCOUNT_ID         # Your Cloudflare account ID
 ```
 
-Without these secrets the container falls back to an ephemeral local workspace (lost on restart).
+### FUSE performance settings
 
-### FUSE performance tuning
-
-The entrypoint mounts with `--attr-cache-ttl 60s --type-cache-ttl 60s` to reduce metadata round-trips. The container also writes a `.vscode/settings.json` on first boot:
+The entrypoint uses `--attr-cache-ttl 60s --type-cache-ttl 60s` to batch metadata calls. On first boot a `.vscode/settings.json` is written to the workspace:
 
 ```json
 {
-  "files.watcherExclude": { "**/.git/objects/**": true, "**/node_modules/**": true },
-  "search.followSymlinks": false
+  "files.watcherExclude": {
+    "**/.git/objects/**": true,
+    "**/node_modules/**": true
+  },
+  "search.followSymlinks": false,
+  "editor.formatOnSave": true
 }
 ```
 
-This prevents the file watcher from hammering the FUSE mount on large repos.
+This prevents the VS Code file watcher from hammering the FUSE mount on large repos.
 
 ---
 
 ## GitHub repo auto-cloning
-
-Set `GITHUB_REPOS` to a comma-separated list of `owner/repo` pairs. On each container start the entrypoint clones any repo that isn't already present, or pulls the latest if it is.
 
 ```jsonc
 // wrangler.jsonc
@@ -164,27 +226,125 @@ Set `GITHUB_REPOS` to a comma-separated list of `owner/repo` pairs. On each cont
 }
 ```
 
+On each container start the entrypoint:
+- Clones any repo not already present (`--depth=50`)
+- Pulls the latest if the repo directory already exists
+
+Because the workspace is R2-backed, the clone only runs once per user.
+
 For private repos:
 
 ```bash
 wrangler secret put GITHUB_TOKEN   # PAT with repo scope
 ```
 
-Repos are cloned with `--depth=50` into `/home/coder/workspace/<repo-name>/`. Because the workspace is R2-backed, the clone only runs once per user — subsequent container starts pull instead.
+---
+
+## Teams dashboard
+
+### First-time setup
+
+The D1 schema is created automatically on the first request to `/admin` — no migrations to run manually.
+
+Designate platform admins (who can see all teams) via `wrangler.jsonc`:
+
+```jsonc
+"vars": {
+  "ADMIN_EMAILS": "alice@example.com,bob@example.com"
+}
+```
+
+Any authenticated user can also access `/admin` for teams they belong to.
+
+### Workflow
+
+1. **Sign in** → go to `/admin`
+2. Click **New Team** → enter a team name → you become the team admin
+3. On the team detail page, enter a developer's email and click **Send invite**
+4. Copy the generated invite URL and share it (Slack, email, etc.)
+5. The developer signs in, visits the invite URL, and is added to the team
+6. The members table shows each developer's **email**, **role**, **container status** (live), and **join date**
+7. Team admins can remove members at any time
+
+Invite links expire after **7 days** and are single-use.
+
+### Routes
+
+| Route | Auth | Description |
+|---|---|---|
+| `GET /admin` | User | Dashboard — teams you belong to (or all teams if admin) |
+| `GET /admin/team/new` | User | Create team form |
+| `POST /admin/team/create` | User | Create team, become admin |
+| `GET /admin/team/:id` | Member | Team detail: members, invites, WakaTime info |
+| `POST /admin/team/:id` | Admin | Invite member or remove member |
+| `GET /admin/accept-invite?token=` | User | Accept invite, join team |
 
 ---
 
-## Endpoints
+## WakaTime time tracking
 
-| Path | Auth | Description |
-|------|------|-------------|
-| `GET /health` | None | Uptime check — returns `{ status: "ok" }` |
-| `GET /auth/login` | None | Google OAuth — redirect to consent screen |
-| `GET /auth/callback` | None | Google OAuth — exchange code, set session cookie |
-| `GET /auth/logout` | None | Google OAuth — clear session, redirect to login |
-| `GET /setup` | Auth | Show the user's unique password (first-visit page) |
-| `POST /reset-password` | Auth | Regenerate password, reboot container, redirect to `/setup` |
-| `GET /*` | Auth | Proxied to the user's code-server instance |
+The [WakaTime](https://wakatime.com) extension is pre-installed in every container. It tracks coding time automatically and syncs to wakatime.com.
+
+### Manual setup (per developer)
+
+Each developer configures their own API key after opening the IDE:
+
+1. Open the Command Palette (`Ctrl+Shift+P`) → **WakaTime: API Key**
+2. Paste the key from [wakatime.com/settings/account](https://wakatime.com/settings/account)
+
+Or via terminal:
+
+```bash
+cat > ~/.wakatime.cfg <<EOF
+[settings]
+api_key = <your-api-key>
+EOF
+```
+
+### Auto-configure for all containers
+
+Set a shared API key (e.g. a WakaTime Teams project key) in `wrangler.jsonc`:
+
+```jsonc
+"vars": {
+  "WAKATIME_API_KEY": "<your-api-key>"
+}
+```
+
+The entrypoint writes `~/.wakatime.cfg` automatically on container start — no manual setup required.
+
+View team stats at [wakatime.com/dashboard](https://wakatime.com/dashboard).
+
+---
+
+## Pre-installed tools
+
+### AI CLIs (available in every terminal)
+
+| Tool | Command | Install |
+|---|---|---|
+| Claude Code | `claude` | `@anthropic-ai/claude-code` |
+| OpenAI Codex | `codex` | `@openai/codex` |
+
+### VS Code extensions
+
+Installed at image build time from [Open VSX Registry](https://open-vsx.org):
+
+| Extension | Purpose |
+|---|---|
+| GitLens | Git blame, history, and branch visualisation |
+| Prettier | Code formatting |
+| ESLint | JavaScript/TypeScript linting |
+| Python | Python language support |
+| Tailwind CSS IntelliSense | Tailwind class autocomplete |
+| Path Intellisense | Filename autocomplete |
+| Code Runner | Run code snippets from the editor |
+| Material Icon Theme | File icons |
+| Error Lens | Inline error and warning display |
+| Code Spell Checker | Spell checking in source files |
+| WakaTime | Automatic time tracking |
+
+Extension failures during image build are non-fatal — the IDE still launches.
 
 ---
 
@@ -193,72 +353,117 @@ Repos are cloned with `--depth=50` into `/home/coder/workspace/<repo-name>/`. Be
 ### Environment variables (`wrangler.jsonc` vars)
 
 | Variable | Default | Description |
-|----------|---------|-------------|
-| `SLEEP_AFTER` | `"30m"` | Container idle timeout. Supports `"30s"`, `"1h"`, etc. Max 24h |
-| `TEAM_DOMAIN` | `""` | Auth option A — CF Access team URL |
-| `POLICY_AUD` | `""` | Auth option A — Access AUD tag |
-| `GOOGLE_CLIENT_ID` | `""` | Auth option B — Google OAuth client ID |
+|---|---|---|
+| `SLEEP_AFTER` | `"30m"` | Container idle timeout. `"30s"`, `"1h"`, etc. Max 24h |
+| `TEAM_DOMAIN` | `""` | Auth A — CF Access team URL |
+| `POLICY_AUD` | `""` | Auth A — CF Access AUD tag |
+| `GOOGLE_CLIENT_ID` | `""` | Auth B — Google OAuth client ID |
+| `ADMIN_EMAILS` | `""` | Comma-separated emails with platform-wide `/admin` access |
+| `WAKATIME_API_KEY` | `""` | Auto-configure WakaTime in every container |
 | `R2_BUCKET_NAME` | `"vscode-cloud-workspaces"` | R2 bucket name |
-| `GITHUB_REPOS` | `""` | Comma-separated `owner/repo` list to clone |
+| `GITHUB_REPOS` | `""` | Comma-separated `owner/repo` list to auto-clone |
 
 ### Secrets (`wrangler secret put`)
 
 | Secret | Description |
-|--------|-------------|
+|---|---|
 | `R2_ACCESS_KEY_ID` | R2 API token key |
 | `R2_SECRET_ACCESS_KEY` | R2 API token secret |
 | `R2_ACCOUNT_ID` | Cloudflare account ID |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret (option B) |
-| `GITHUB_TOKEN` | GitHub PAT for private repos |
+| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret (auth option B) |
+| `GITHUB_TOKEN` | GitHub PAT with `repo` scope (private repos only) |
+
+### Cloudflare resources
+
+| Resource | Binding | Purpose |
+|---|---|---|
+| R2 bucket | `WORKSPACE_BUCKET` | Workspace file storage |
+| D1 database | `TEAMS_DB` | Teams, members, invites |
+| KV namespace | `SESSION_STORE` | Google OAuth sessions (auth B only) |
 
 ### Container sizing
 
-Set in `wrangler.jsonc` → `containers[].instance_type`:
+Set in `wrangler.jsonc` → `containers[0].instance_type`:
 
-| Type | vCPU | RAM | Cost/hr | Use case |
-|------|------|-----|---------|---------|
-| `basic` | 0.5 | 512 MB | ~$0.15 | Light use only |
-| `standard-1` | 1 | 2 GB | ~$0.30 | **Default — works well** |
-| `standard-2` | 2 | 4 GB | ~$0.60 | Heavier projects / monorepos |
+| Type | vCPU | RAM | Cost/hr | Recommended for |
+|---|---|---|---|---|
+| `basic` | 0.5 | 512 MB | ~$0.15 | Light use / testing only |
+| `standard-1` | 1 | 2 GB | ~$0.30 | **Default — most projects** |
+| `standard-2` | 2 | 4 GB | ~$0.60 | Monorepos / heavy workloads |
 
 ---
 
 ## Cost estimates
 
-Containers are **on-demand** by default — billed only while running, ~$0 while sleeping.
+Containers are **on-demand** — billed only while running, ~$0 while sleeping.
 
 | Scenario | Est. monthly cost |
-|----------|------------------|
-| 1 user, always-on (standard-1) | ~$75 |
-| 10 users, 2hr/day avg (standard-1) | ~$18 |
-| 100 users, 1hr/day avg (standard-1) | ~$80 |
+|---|---|
+| 1 developer, always-on (`standard-1`) | ~$75 |
+| 10 developers, 2 hr/day avg | ~$18 |
+| 100 developers, 1 hr/day avg | ~$80 |
 
-Add $5/mo for Workers Paid plan + ~$10 for KV/R2 usage at scale.
+Add $5/mo for Workers Paid plan + ~$10 for KV/R2/D1 usage at scale.
 
-Check container status:
+Check live container status:
+
 ```bash
 npx wrangler containers list --status
 ```
 
 ---
 
-## Resetting a password
+## Endpoints
 
-```bash
-curl -X POST https://code.example.com/reset-password \
-  -H "Cf-Access-Jwt-Assertion: <token>"
-  # or pass the __session cookie for Google OAuth
-```
-
-This deletes the stored password from SQLite, stops the container, then redirects to `/setup` where the new password is shown. The container restarts fresh on next request.
+| Path | Auth | Description |
+|---|---|---|
+| `GET /` | — | Landing page (unauthenticated) or proxied to code-server (authenticated) |
+| `GET /health` | None | `{ status: "ok", ts: <ms> }` |
+| `GET /auth/login` | None | Redirect to Google OAuth consent screen |
+| `GET /auth/callback` | None | OAuth token exchange, set session cookie |
+| `GET /auth/logout` | None | Clear session, redirect to landing |
+| `GET /status` | Auth | JSON: `{ userId, email, container: { status, ... } }` |
+| `GET /admin` | Auth | Teams dashboard |
+| `GET /admin/team/new` | Auth | Create team form |
+| `POST /admin/team/create` | Auth | Submit new team |
+| `GET /admin/team/:id` | Member | Team detail: members, invites |
+| `POST /admin/team/:id` | Admin | Invite or remove a member |
+| `GET /admin/accept-invite?token=` | Auth | Accept invite, join team |
 
 ---
 
 ## Local development
 
 ```bash
-npm run dev      # wrangler dev (no real containers; simulates Workers runtime)
-npm run build    # type-check only
+npm run dev      # wrangler dev — simulates Workers runtime (no real containers)
+npm run build    # TypeScript type-check only
 ```
 
-In `wrangler dev`, leave all auth vars empty and use `?user=yourname` to switch between simulated users.
+In dev mode leave all auth vars empty and append `?user=yourname` to switch between simulated users:
+
+```
+http://localhost:8787/?user=alice
+http://localhost:8787/admin?user=alice
+```
+
+---
+
+## Troubleshooting
+
+**Container won't start**
+Run `npx wrangler containers list --status`. Cold starts can take up to ~13 seconds on first request after a sleep period.
+
+**R2 mount failing / workspace empty after restart**
+Check that all three R2 secrets are set (`R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_ACCOUNT_ID`). The container logs will show `[entrypoint] R2 mount ready` or the fallback message.
+
+**WakaTime not tracking**
+Open the Command Palette → **WakaTime: API Key** and verify the key. Alternatively check `cat ~/.wakatime.cfg` in the integrated terminal.
+
+**Google OAuth "redirect_uri_mismatch"**
+The redirect URI in Google Cloud Console must exactly match `https://<your-worker>.workers.dev/auth/callback` — no trailing slash.
+
+**Invite link not working**
+Invite links expire after 7 days and are single-use. Generate a new one from the team detail page.
+
+**Teams dashboard empty**
+Verify `TEAMS_DB` has a valid `database_id` in `wrangler.jsonc` and that `wrangler d1 create vscode-cloud-teams` was run. The D1 schema is created automatically on first `/admin` request.

--- a/apps/vscode-cloud/entrypoint.sh
+++ b/apps/vscode-cloud/entrypoint.sh
@@ -63,7 +63,8 @@ if [[ -n "$GITHUB_REPOS" ]]; then
 
     if [[ -d "$target/.git" ]]; then
       echo "[entrypoint] Pulling latest for ${repo}"
-      git -C "$target" pull --ff-only 2>/dev/null || echo "[entrypoint] Warning: pull failed for ${repo}, using cached copy"
+      git -C "$target" pull --ff-only 2>/dev/null \
+        || echo "[entrypoint] Warning: pull failed for ${repo}, using cached copy"
     else
       echo "[entrypoint] Cloning ${repo}"
       git clone --depth=50 "https://github.com/${repo}.git" "$target" \
@@ -72,7 +73,7 @@ if [[ -n "$GITHUB_REPOS" ]]; then
   done
 fi
 
-# ── VSCode workspace settings for FUSE performance ───────────────────────────
+# ── VSCode workspace settings ─────────────────────────────────────────────────
 # Written only once; users can override later without it being clobbered.
 VSCODE_DIR="${WORKSPACE}/.vscode"
 SETTINGS_FILE="${VSCODE_DIR}/settings.json"
@@ -80,6 +81,16 @@ if [[ ! -f "$SETTINGS_FILE" ]]; then
   mkdir -p "$VSCODE_DIR"
   cat > "$SETTINGS_FILE" <<'SETTINGS'
 {
+  "workbench.iconTheme": "material-icon-theme",
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.fontFamily": "'JetBrains Mono', 'Fira Code', monospace",
+  "editor.fontSize": 14,
+  "editor.fontLigatures": true,
+  "editor.tabSize": 2,
+  "editor.wordWrap": "on",
+  "terminal.integrated.defaultProfile.linux": "bash",
+  "terminal.integrated.fontSize": 13,
   "files.watcherExclude": {
     "**/.git/objects/**": true,
     "**/.git/subtree-cache/**": true,
@@ -87,7 +98,8 @@ if [[ ! -f "$SETTINGS_FILE" ]]; then
     "**/__pycache__/**": true
   },
   "files.exclude": {
-    "**/.git": true
+    "**/.git": true,
+    "**/__pycache__": true
   },
   "search.followSymlinks": false,
   "search.exclude": {
@@ -95,13 +107,16 @@ if [[ ! -f "$SETTINGS_FILE" ]]; then
     "**/.git": true,
     "**/__pycache__": true
   },
-  "editor.formatOnSave": true,
-  "terminal.integrated.defaultProfile.linux": "bash"
+  "gitlens.currentLine.enabled": true,
+  "errorLens.enabledDiagnosticLevels": ["error", "warning"],
+  "cSpell.enabled": true
 }
 SETTINGS
   echo "[entrypoint] VSCode workspace settings written"
 fi
 
 # ── Start code-server ─────────────────────────────────────────────────────────
-# PASSWORD is injected by the Durable Object via envVars before container start.
-exec /usr/bin/entrypoint.sh --bind-addr 0.0.0.0:8080 --auth password "${WORKSPACE}"
+# Auth is handled by the Cloudflare Worker (CF Access JWT or Google OAuth session).
+# The container is only reachable through the authenticated Worker, so --auth none
+# is safe — no password prompt is shown to users.
+exec /usr/bin/entrypoint.sh --bind-addr 0.0.0.0:8080 --auth none "${WORKSPACE}"

--- a/apps/vscode-cloud/entrypoint.sh
+++ b/apps/vscode-cloud/entrypoint.sh
@@ -115,6 +115,17 @@ SETTINGS
   echo "[entrypoint] VSCode workspace settings written"
 fi
 
+# ── WakaTime auto-config ─────────────────────────────────────────────────────
+# If WAKATIME_API_KEY is injected by the Worker, write ~/.wakatime.cfg so the
+# pre-installed extension activates without manual setup.
+if [[ -n "$WAKATIME_API_KEY" ]]; then
+  cat > "$HOME/.wakatime.cfg" <<WAKA
+[settings]
+api_key = ${WAKATIME_API_KEY}
+WAKA
+  echo "[entrypoint] WakaTime configured"
+fi
+
 # ── Start code-server ─────────────────────────────────────────────────────────
 # Auth is handled by the Cloudflare Worker (CF Access JWT or Google OAuth session).
 # The container is only reachable through the authenticated Worker, so --auth none

--- a/apps/vscode-cloud/src/admin.ts
+++ b/apps/vscode-cloud/src/admin.ts
@@ -1,0 +1,468 @@
+import type { Env } from "./index";
+import type { Team, TeamMember, TeamInvite } from "./teams";
+import {
+  initTeamsSchema,
+  createTeam,
+  getAllTeams,
+  getTeamsByUser,
+  getTeam,
+  getTeamMembers,
+  getMemberRole,
+  addMember,
+  removeMember,
+  createInvite,
+  getInvite,
+  getPendingInvites,
+  deleteInvite,
+} from "./teams";
+import { emailToUserId } from "./auth";
+
+// ─── Shared HTML shell ────────────────────────────────────────────────────────
+
+function shell(title: string, body: string, email: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>${title} — Teams</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117; --surface: #161b22; --surface2: #1c2128; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #238636; --green-h: #2ea043; --red: #da3633; --orange: #d29922;
+    }
+    body { font-family: system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
+    nav {
+      padding: .75rem 1.5rem; border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; gap: 1.5rem;
+    }
+    .nav-logo { font-weight: 700; color: var(--text); text-decoration: none; font-size: .95rem; }
+    .nav-logo span { color: var(--accent); }
+    .nav-links { display: flex; gap: 1rem; flex: 1; }
+    .nav-links a { color: var(--muted); text-decoration: none; font-size: .875rem; }
+    .nav-links a:hover, .nav-links a.active { color: var(--text); }
+    .nav-user { font-size: .8rem; color: var(--muted); }
+    .nav-user a { color: var(--muted); text-decoration: none; }
+    .nav-user a:hover { color: var(--text); }
+    .container { max-width: 960px; margin: 0 auto; padding: 2rem 1.5rem; }
+    h1 { font-size: 1.5rem; font-weight: 700; margin-bottom: .25rem; }
+    h2 { font-size: 1.1rem; font-weight: 600; margin-bottom: 1rem; }
+    .page-sub { color: var(--muted); font-size: .9rem; margin-bottom: 2rem; }
+    .card {
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: 10px; overflow: hidden; margin-bottom: 1.5rem;
+    }
+    .card-header {
+      padding: .875rem 1.25rem; border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .card-header h2 { margin: 0; }
+    .card-body { padding: 1.25rem; }
+    table { width: 100%; border-collapse: collapse; font-size: .875rem; }
+    th { text-align: left; padding: .5rem .75rem; color: var(--muted); font-weight: 500;
+         font-size: .75rem; text-transform: uppercase; letter-spacing: .04em;
+         border-bottom: 1px solid var(--border); }
+    td { padding: .625rem .75rem; border-bottom: 1px solid var(--border); vertical-align: middle; }
+    tr:last-child td { border-bottom: none; }
+    tr:hover td { background: var(--surface2); }
+    .badge {
+      display: inline-block; padding: .15rem .55rem; border-radius: 999px;
+      font-size: .72rem; font-weight: 500; letter-spacing: .02em;
+    }
+    .badge-admin { background: #1d2d3e; color: var(--accent); border: 1px solid #1f4068; }
+    .badge-member { background: #1c2d1f; color: #3fb950; border: 1px solid #1b4721; }
+    .badge-running { background: #1c2d1f; color: #3fb950; border: 1px solid #1b4721; }
+    .badge-stopped { background: #2d1f1f; color: #f85149; border: 1px solid #4d1e1e; }
+    .badge-sleeping { background: #2d2a1a; color: var(--orange); border: 1px solid #4d3a0d; }
+    .btn {
+      display: inline-flex; align-items: center; gap: .4rem;
+      padding: .4rem .9rem; border-radius: 6px; font-size: .825rem; font-weight: 500;
+      text-decoration: none; border: none; cursor: pointer; transition: background .15s;
+    }
+    .btn-primary { background: var(--green); color: #fff; }
+    .btn-primary:hover { background: var(--green-h); }
+    .btn-danger { background: transparent; color: var(--red); border: 1px solid #4d1e1e; }
+    .btn-danger:hover { background: #2d1f1f; }
+    .btn-ghost { background: transparent; color: var(--muted); border: 1px solid var(--border); }
+    .btn-ghost:hover { background: var(--surface2); color: var(--text); }
+    .form-row { display: flex; gap: .75rem; align-items: flex-end; flex-wrap: wrap; margin-top: 1rem; }
+    .form-group { display: flex; flex-direction: column; gap: .35rem; flex: 1; min-width: 200px; }
+    label { font-size: .8rem; color: var(--muted); }
+    input[type=text], input[type=email] {
+      background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+      color: var(--text); padding: .45rem .75rem; font-size: .875rem; width: 100%;
+    }
+    input:focus { outline: none; border-color: var(--accent); }
+    .invite-url {
+      background: var(--bg); border: 1px solid var(--border); border-radius: 6px;
+      padding: .6rem .875rem; font-family: monospace; font-size: .8rem;
+      color: var(--accent); word-break: break-all; margin-top: .75rem;
+    }
+    .empty { color: var(--muted); font-size: .875rem; padding: .75rem 0; }
+    .flash {
+      padding: .75rem 1rem; border-radius: 8px; margin-bottom: 1.5rem; font-size: .875rem;
+    }
+    .flash-ok { background: #1c2d1f; border: 1px solid #1b4721; color: #3fb950; }
+    .flash-err { background: #2d1f1f; border: 1px solid #4d1e1e; color: #f85149; }
+    .top-bar { display: flex; align-items: center; justify-content: space-between; margin-bottom: 1.75rem; }
+    .top-bar-title h1 { margin: 0; }
+    .team-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+      gap: 1rem; margin-top: 1.5rem;
+    }
+    .team-card {
+      background: var(--surface); border: 1px solid var(--border); border-radius: 10px;
+      padding: 1.25rem; display: flex; flex-direction: column; gap: .75rem;
+    }
+    .team-card-name { font-size: 1rem; font-weight: 600; }
+    .team-card-meta { font-size: .8rem; color: var(--muted); }
+    .team-card-footer { display: flex; justify-content: flex-end; }
+  </style>
+</head>
+<body>
+  <nav>
+    <a class="nav-logo" href="/">Cloud <span>IDE</span></a>
+    <div class="nav-links">
+      <a href="/" >My IDE</a>
+      <a href="/admin" class="active">Teams</a>
+      <a href="/status">Status</a>
+    </div>
+    <span class="nav-user">${email} · <a href="/auth/logout">Sign out</a></span>
+  </nav>
+  <div class="container">
+    ${body}
+  </div>
+</body>
+</html>`;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function statusBadge(status: string): string {
+  const cls =
+    status === "running" || status === "healthy"
+      ? "badge-running"
+      : status === "stopped" || status === "stopped_with_code"
+      ? "badge-stopped"
+      : "badge-sleeping";
+  return `<span class="badge ${cls}">${status}</span>`;
+}
+
+async function getContainerStatus(
+  doNs: DurableObjectNamespace,
+  userId: string
+): Promise<string> {
+  try {
+    const stub = doNs.getByName(userId) as unknown as { fetch(r: Request): Promise<Response> };
+    const r = await stub.fetch(new Request("http://internal/__internal/state"));
+    const state = (await r.json()) as { status?: string };
+    return state?.status ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+// ─── Route handler ────────────────────────────────────────────────────────────
+
+export async function handleAdminRoutes(
+  request: Request,
+  env: Env,
+  url: URL,
+  userEmail: string,
+  userId: string
+): Promise<Response | null> {
+  if (!env.TEAMS_DB) return null;
+  if (!url.pathname.startsWith("/admin")) return null;
+
+  await initTeamsSchema(env.TEAMS_DB);
+
+  const isGlobalAdmin =
+    env.ADMIN_EMAILS
+      ?.split(",")
+      .map((e) => e.trim().toLowerCase())
+      .includes(userEmail.toLowerCase()) ?? false;
+
+  const path = url.pathname;
+  const flash = (msg: string, ok = true) =>
+    `<div class="flash ${ok ? "flash-ok" : "flash-err"}">${msg}</div>`;
+
+  // ── GET /admin ─────────────────────────────────────────────────────────────
+  if (path === "/admin" && request.method === "GET") {
+    const teams = isGlobalAdmin
+      ? await getAllTeams(env.TEAMS_DB)
+      : await getTeamsByUser(env.TEAMS_DB, userId);
+
+    const cards = teams.length
+      ? teams
+          .map(
+            (t) => `
+        <div class="team-card">
+          <div class="team-card-name">${esc(t.name)}</div>
+          <div class="team-card-meta">Created ${new Date(t.created_at).toLocaleDateString()}</div>
+          <div class="team-card-footer">
+            <a class="btn btn-ghost" href="/admin/team/${t.id}">Manage &rarr;</a>
+          </div>
+        </div>`
+          )
+          .join("")
+      : `<p class="empty">No teams yet. Create one to get started.</p>`;
+
+    const body = `
+      <div class="top-bar">
+        <div class="top-bar-title">
+          <h1>Teams Dashboard</h1>
+          <p class="page-sub">Manage your developer teams, track activity, and invite members.</p>
+        </div>
+        <a class="btn btn-primary" href="/admin/team/new">+ New Team</a>
+      </div>
+      <div class="team-grid">${cards}</div>`;
+    return new Response(shell("Dashboard", body, userEmail), {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // ── GET /admin/team/new ────────────────────────────────────────────────────
+  if (path === "/admin/team/new" && request.method === "GET") {
+    const body = `
+      <div class="top-bar">
+        <div class="top-bar-title"><h1>Create Team</h1></div>
+        <a class="btn btn-ghost" href="/admin">&larr; Back</a>
+      </div>
+      <div class="card">
+        <div class="card-body">
+          <form method="POST" action="/admin/team/create">
+            <div class="form-group" style="max-width:400px">
+              <label for="name">Team name</label>
+              <input type="text" id="name" name="name" placeholder="e.g. Frontend Team" required>
+            </div>
+            <div class="form-row" style="margin-top:1.25rem">
+              <button type="submit" class="btn btn-primary">Create team</button>
+              <a class="btn btn-ghost" href="/admin">Cancel</a>
+            </div>
+          </form>
+        </div>
+      </div>`;
+    return new Response(shell("New Team", body, userEmail), {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // ── POST /admin/team/create ────────────────────────────────────────────────
+  if (path === "/admin/team/create" && request.method === "POST") {
+    const form = await request.formData();
+    const name = (form.get("name") as string | null)?.trim();
+    if (!name) return redirect("/admin/team/new");
+    const team = await createTeam(env.TEAMS_DB, name, userId, userEmail);
+    return redirect(`/admin/team/${team.id}`);
+  }
+
+  // ── /admin/team/:id ────────────────────────────────────────────────────────
+  const teamMatch = path.match(/^\/admin\/team\/([^/]+)$/);
+  if (teamMatch) {
+    const teamId = teamMatch[1];
+    const team = await getTeam(env.TEAMS_DB, teamId);
+    if (!team) return new Response("Team not found", { status: 404 });
+
+    const role = await getMemberRole(env.TEAMS_DB, teamId, userId);
+    if (!role && !isGlobalAdmin)
+      return new Response("Forbidden", { status: 403 });
+
+    const isTeamAdmin = role === "admin" || isGlobalAdmin;
+
+    if (request.method === "POST") {
+      const form = await request.formData();
+      const action = form.get("_action") as string | null;
+
+      if (action === "invite" && isTeamAdmin) {
+        const email = (form.get("email") as string | null)?.trim().toLowerCase();
+        if (!email) return redirect(`/admin/team/${teamId}?err=noemail`);
+        const token = await createInvite(env.TEAMS_DB, teamId, email, userId);
+        return redirect(`/admin/team/${teamId}?invite=${token}`);
+      }
+
+      if (action === "remove" && isTeamAdmin) {
+        const targetId = form.get("member_id") as string | null;
+        if (targetId && targetId !== userId)
+          await removeMember(env.TEAMS_DB, teamId, targetId);
+        return redirect(`/admin/team/${teamId}`);
+      }
+    }
+
+    // GET — build team detail page
+    const [members, invites] = await Promise.all([
+      getTeamMembers(env.TEAMS_DB, teamId),
+      isTeamAdmin ? getPendingInvites(env.TEAMS_DB, teamId) : Promise.resolve<TeamInvite[]>([]),
+    ]);
+
+    // Fetch container status for each member in parallel
+    const statuses = await Promise.all(
+      members.map((m) => getContainerStatus(env.CODE_SERVER, m.user_id))
+    );
+
+    const newInviteToken = url.searchParams.get("invite");
+    const errParam = url.searchParams.get("err");
+
+    const inviteFlash = newInviteToken
+      ? flash(
+          `Invite link generated — copy and send it to the new team member:
+           <div class="invite-url">${url.origin}/admin/accept-invite?token=${newInviteToken}</div>`,
+          true
+        )
+      : errParam === "noemail"
+      ? flash("Please enter an email address.", false)
+      : "";
+
+    const memberRows = members
+      .map(
+        (m, i) => `
+        <tr>
+          <td>${esc(m.email)}</td>
+          <td><span class="badge ${m.role === "admin" ? "badge-admin" : "badge-member"}">${m.role}</span></td>
+          <td>${statusBadge(statuses[i])}</td>
+          <td>${new Date(m.joined_at).toLocaleDateString()}</td>
+          <td>
+            ${
+              isTeamAdmin && m.user_id !== userId
+                ? `<form method="POST" style="display:inline">
+                     <input type="hidden" name="_action" value="remove">
+                     <input type="hidden" name="member_id" value="${esc(m.user_id)}">
+                     <button type="submit" class="btn btn-danger"
+                       onclick="return confirm('Remove ${esc(m.email)} from this team?')">Remove</button>
+                   </form>`
+                : `<span class="badge badge-admin" style="opacity:.5">you</span>`
+            }
+          </td>
+        </tr>`
+      )
+      .join("");
+
+    const inviteRows = invites
+      .map(
+        (inv) => `
+        <tr>
+          <td>${esc(inv.email)}</td>
+          <td>Expires ${new Date(inv.expires_at).toLocaleDateString()}</td>
+          <td>
+            <a class="btn btn-ghost" style="font-size:.75rem"
+               href="/admin/accept-invite?token=${inv.token}">Copy link</a>
+          </td>
+        </tr>`
+      )
+      .join("");
+
+    const inviteForm = isTeamAdmin
+      ? `<form method="POST">
+           <input type="hidden" name="_action" value="invite">
+           <div class="form-row">
+             <div class="form-group">
+               <label for="inv-email">Email address</label>
+               <input type="email" id="inv-email" name="email" placeholder="developer@example.com" required>
+             </div>
+             <button type="submit" class="btn btn-primary" style="margin-bottom:0">Send invite</button>
+           </div>
+         </form>`
+      : "";
+
+    const body = `
+      <div class="top-bar">
+        <div class="top-bar-title">
+          <h1>${esc(team.name)}</h1>
+          <p class="page-sub">${members.length} member${members.length !== 1 ? "s" : ""}</p>
+        </div>
+        <a class="btn btn-ghost" href="/admin">&larr; All teams</a>
+      </div>
+      ${inviteFlash}
+      <div class="card">
+        <div class="card-header"><h2>Members</h2></div>
+        <table>
+          <thead>
+            <tr>
+              <th>Email</th><th>Role</th><th>Container</th><th>Joined</th><th></th>
+            </tr>
+          </thead>
+          <tbody>${memberRows || `<tr><td colspan="5" class="empty">No members yet.</td></tr>`}</tbody>
+        </table>
+      </div>
+      ${
+        isTeamAdmin
+          ? `<div class="card">
+               <div class="card-header"><h2>Invite member</h2></div>
+               <div class="card-body">
+                 <p style="font-size:.85rem;color:var(--muted);margin-bottom:.75rem">
+                   An invite link will be generated — share it with your developer via email or Slack.
+                   Links expire after 7 days.
+                 </p>
+                 ${inviteForm}
+               </div>
+             </div>
+             <div class="card">
+               <div class="card-header"><h2>Pending invites</h2></div>
+               ${
+                 invites.length
+                   ? `<table>
+                        <thead><tr><th>Email</th><th>Expiry</th><th></th></tr></thead>
+                        <tbody>${inviteRows}</tbody>
+                      </table>`
+                   : `<div class="card-body"><p class="empty">No pending invites.</p></div>`
+               }
+             </div>`
+          : ""
+      }
+      <div class="card">
+        <div class="card-header"><h2>WakaTime time tracking</h2></div>
+        <div class="card-body" style="font-size:.875rem;color:var(--muted);line-height:1.6">
+          WakaTime is pre-installed in every container. Each developer configures their own
+          API key via <code>Settings → Extensions → WakaTime</code> or the
+          <code>~/.wakatime.cfg</code> file in their terminal.
+          View team stats at
+          <a href="https://wakatime.com/dashboard" target="_blank" rel="noopener"
+             style="color:var(--accent)">wakatime.com/dashboard</a>
+          once members have connected their accounts.
+        </div>
+      </div>`;
+
+    return new Response(shell(team.name, body, userEmail), {
+      headers: { "Content-Type": "text/html; charset=utf-8" },
+    });
+  }
+
+  // ── GET /admin/accept-invite ───────────────────────────────────────────────
+  if (path === "/admin/accept-invite" && request.method === "GET") {
+    const token = url.searchParams.get("token");
+    if (!token) return new Response("Missing token", { status: 400 });
+
+    const invite = await getInvite(env.TEAMS_DB, token);
+    if (!invite || invite.expires_at < Date.now()) {
+      return new Response(
+        shell(
+          "Invalid invite",
+          `<div class="flash flash-err">This invite link is invalid or has expired.</div>
+           <a class="btn btn-ghost" href="/admin">&larr; Dashboard</a>`,
+          userEmail
+        ),
+        { headers: { "Content-Type": "text/html; charset=utf-8" } }
+      );
+    }
+
+    await Promise.all([
+      addMember(env.TEAMS_DB, invite.team_id, userId, userEmail),
+      deleteInvite(env.TEAMS_DB, token),
+    ]);
+
+    return redirect(`/admin/team/${invite.team_id}`);
+  }
+
+  return null;
+}
+
+// ─── Utils ────────────────────────────────────────────────────────────────────
+
+function redirect(location: string): Response {
+  return new Response(null, { status: 303, headers: { Location: location } });
+}
+
+function esc(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}

--- a/apps/vscode-cloud/src/auth.ts
+++ b/apps/vscode-cloud/src/auth.ts
@@ -33,59 +33,8 @@ export async function handleAuthRoutes(
 ): Promise<Response | null> {
   if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET || !env.SESSION_STORE) return null;
 
-  // ── /auth/login landing page ──────────────────────────────────────────────
-  // Show a branded sign-in page rather than jumping straight to Google so
-  // users know which app they are authenticating into.
-  if (url.pathname === "/auth/login" && request.method === "GET" && !url.searchParams.has("direct")) {
-    const params = new URLSearchParams({
-      client_id: env.GOOGLE_CLIENT_ID,
-      redirect_uri: `${url.origin}/auth/callback`,
-      response_type: "code",
-      scope: "openid email profile",
-      prompt: "select_account",
-    });
-    const googleUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
-    const html = `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Sign in — code-server</title>
-  <style>
-    body{font-family:system-ui,sans-serif;background:#0d1117;color:#e6edf3;
-         display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
-    .card{background:#161b22;border:1px solid #30363d;border-radius:12px;
-          padding:2.5rem;max-width:380px;width:100%;text-align:center}
-    h1{margin:0 0 .5rem;font-size:1.4rem}
-    p{color:#8b949e;margin:0 0 2rem;font-size:.9rem}
-    .google-btn{display:inline-flex;align-items:center;gap:.75rem;background:#fff;color:#3c4043;
-                border-radius:6px;padding:.65rem 1.5rem;text-decoration:none;font-size:.95rem;
-                font-weight:500;border:1px solid #dadce0}
-    .google-btn:hover{background:#f8f8f8;box-shadow:0 1px 3px rgba(0,0,0,.2)}
-    .google-logo{width:20px;height:20px;flex-shrink:0}
-  </style>
-</head>
-<body>
-  <div class="card">
-    <h1>Sign in to code-server</h1>
-    <p>Your personal cloud IDE — one container, fully isolated.</p>
-    <a class="google-btn" href="${googleUrl}">
-      <svg class="google-logo" viewBox="0 0 48 48">
-        <path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9 3.2l6.7-6.7C35.7 2.4 30.2 0 24 0 14.7 0 6.7 5.4 2.8 13.3l7.8 6C12.4 13 17.8 9.5 24 9.5z"/>
-        <path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.1-.4-4.5H24v8.5h12.7c-.6 3-2.3 5.5-4.8 7.2l7.5 5.8c4.4-4 7.1-10 7.1-17z"/>
-        <path fill="#FBBC05" d="M10.6 28.7A14.6 14.6 0 0 1 9.5 24c0-1.6.3-3.2.8-4.7l-7.8-6A23.9 23.9 0 0 0 0 24c0 3.9.9 7.5 2.8 10.7l7.8-6z"/>
-        <path fill="#34A853" d="M24 48c6.2 0 11.4-2 15.2-5.5l-7.5-5.8c-2 1.4-4.6 2.2-7.7 2.2-6.2 0-11.5-4.2-13.4-9.8l-7.8 6C6.7 42.6 14.7 48 24 48z"/>
-      </svg>
-      Sign in with Google
-    </a>
-  </div>
-</body>
-</html>`;
-    return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
-  }
-
-  // ── /auth/login?direct — skip landing page, redirect straight to Google ──
-  if (url.pathname === "/auth/login" && url.searchParams.has("direct")) {
+  // ── /auth/login — redirect to Google consent screen ─────────────────────
+  if (url.pathname === "/auth/login" && request.method === "GET") {
     const params = new URLSearchParams({
       client_id: env.GOOGLE_CLIENT_ID,
       redirect_uri: `${url.origin}/auth/callback`,
@@ -138,11 +87,11 @@ export async function handleAuthRoutes(
       { expirationTtl: ttl }
     );
 
-    // Redirect to /setup so users see their password before code-server prompts for it.
+    // Redirect to / — the Worker proxies straight to code-server (no password page needed).
     return new Response(null, {
       status: 302,
       headers: {
-        Location: "/setup",
+        Location: "/",
         "Set-Cookie": `__session=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${ttl}`,
       },
     });

--- a/apps/vscode-cloud/src/auth.ts
+++ b/apps/vscode-cloud/src/auth.ts
@@ -33,8 +33,59 @@ export async function handleAuthRoutes(
 ): Promise<Response | null> {
   if (!env.GOOGLE_CLIENT_ID || !env.GOOGLE_CLIENT_SECRET || !env.SESSION_STORE) return null;
 
-  // ── /auth/login — redirect to Google consent screen ──────────────────────
-  if (url.pathname === "/auth/login") {
+  // ── /auth/login landing page ──────────────────────────────────────────────
+  // Show a branded sign-in page rather than jumping straight to Google so
+  // users know which app they are authenticating into.
+  if (url.pathname === "/auth/login" && request.method === "GET" && !url.searchParams.has("direct")) {
+    const params = new URLSearchParams({
+      client_id: env.GOOGLE_CLIENT_ID,
+      redirect_uri: `${url.origin}/auth/callback`,
+      response_type: "code",
+      scope: "openid email profile",
+      prompt: "select_account",
+    });
+    const googleUrl = `https://accounts.google.com/o/oauth2/v2/auth?${params}`;
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Sign in — code-server</title>
+  <style>
+    body{font-family:system-ui,sans-serif;background:#0d1117;color:#e6edf3;
+         display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
+    .card{background:#161b22;border:1px solid #30363d;border-radius:12px;
+          padding:2.5rem;max-width:380px;width:100%;text-align:center}
+    h1{margin:0 0 .5rem;font-size:1.4rem}
+    p{color:#8b949e;margin:0 0 2rem;font-size:.9rem}
+    .google-btn{display:inline-flex;align-items:center;gap:.75rem;background:#fff;color:#3c4043;
+                border-radius:6px;padding:.65rem 1.5rem;text-decoration:none;font-size:.95rem;
+                font-weight:500;border:1px solid #dadce0}
+    .google-btn:hover{background:#f8f8f8;box-shadow:0 1px 3px rgba(0,0,0,.2)}
+    .google-logo{width:20px;height:20px;flex-shrink:0}
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>Sign in to code-server</h1>
+    <p>Your personal cloud IDE — one container, fully isolated.</p>
+    <a class="google-btn" href="${googleUrl}">
+      <svg class="google-logo" viewBox="0 0 48 48">
+        <path fill="#EA4335" d="M24 9.5c3.5 0 6.6 1.2 9 3.2l6.7-6.7C35.7 2.4 30.2 0 24 0 14.7 0 6.7 5.4 2.8 13.3l7.8 6C12.4 13 17.8 9.5 24 9.5z"/>
+        <path fill="#4285F4" d="M46.5 24.5c0-1.6-.1-3.1-.4-4.5H24v8.5h12.7c-.6 3-2.3 5.5-4.8 7.2l7.5 5.8c4.4-4 7.1-10 7.1-17z"/>
+        <path fill="#FBBC05" d="M10.6 28.7A14.6 14.6 0 0 1 9.5 24c0-1.6.3-3.2.8-4.7l-7.8-6A23.9 23.9 0 0 0 0 24c0 3.9.9 7.5 2.8 10.7l7.8-6z"/>
+        <path fill="#34A853" d="M24 48c6.2 0 11.4-2 15.2-5.5l-7.5-5.8c-2 1.4-4.6 2.2-7.7 2.2-6.2 0-11.5-4.2-13.4-9.8l-7.8 6C6.7 42.6 14.7 48 24 48z"/>
+      </svg>
+      Sign in with Google
+    </a>
+  </div>
+</body>
+</html>`;
+    return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
+  }
+
+  // ── /auth/login?direct — skip landing page, redirect straight to Google ──
+  if (url.pathname === "/auth/login" && url.searchParams.has("direct")) {
     const params = new URLSearchParams({
       client_id: env.GOOGLE_CLIENT_ID,
       redirect_uri: `${url.origin}/auth/callback`,
@@ -87,10 +138,11 @@ export async function handleAuthRoutes(
       { expirationTtl: ttl }
     );
 
+    // Redirect to /setup so users see their password before code-server prompts for it.
     return new Response(null, {
       status: 302,
       headers: {
-        Location: "/",
+        Location: "/setup",
         "Set-Cookie": `__session=${sessionId}; Path=/; HttpOnly; SameSite=Lax; Max-Age=${ttl}`,
       },
     });
@@ -128,7 +180,7 @@ export async function authenticate(
     return authenticateViaAccess(request, env);
   }
 
-  if (env.GOOGLE_CLIENT_ID && env.SESSION_STORE) {
+  if (env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET && env.SESSION_STORE) {
     return authenticateViaGoogleSession(request, env);
   }
 

--- a/apps/vscode-cloud/src/index.ts
+++ b/apps/vscode-cloud/src/index.ts
@@ -1,25 +1,32 @@
 import { Container } from "@cloudflare/containers";
 import type { StopParams } from "@cloudflare/containers";
 import { authenticate, handleAuthRoutes } from "./auth";
+import { handleAdminRoutes } from "./admin";
 
 // ─── Env ─────────────────────────────────────────────────────────────────────
 
 export interface Env {
   CODE_SERVER: DurableObjectNamespace;
 
-  // ── Cloudflare Access (production — option A) ─────────────────────────────
+  // ── Cloudflare Access (option A) ──────────────────────────────────────────
   TEAM_DOMAIN?: string;
   POLICY_AUD?: string;
 
-  // ── Google OAuth (production — option B) ─────────────────────────────────
+  // ── Google OAuth (option B) ───────────────────────────────────────────────
   GOOGLE_CLIENT_ID?: string;
   GOOGLE_CLIENT_SECRET?: string;
   SESSION_STORE?: KVNamespace;
 
+  // ── Teams ─────────────────────────────────────────────────────────────────
+  /** D1 database for teams, members, and invites */
+  TEAMS_DB?: D1Database;
+  /** Comma-separated emails with platform-wide admin access to /admin */
+  ADMIN_EMAILS?: string;
+
   // ── Container behaviour ───────────────────────────────────────────────────
   SLEEP_AFTER: string;
 
-  // ── R2 workspace storage ─────────────────────────────────────────────────
+  // ── R2 workspace storage ──────────────────────────────────────────────────
   WORKSPACE_BUCKET: R2Bucket;
   R2_ACCESS_KEY_ID?: string;
   R2_SECRET_ACCESS_KEY?: string;
@@ -29,25 +36,22 @@ export interface Env {
   // ── GitHub repo auto-cloning ──────────────────────────────────────────────
   GITHUB_REPOS?: string;
   GITHUB_TOKEN?: string;
+
+  // ── WakaTime ──────────────────────────────────────────────────────────────
+  /** Optional: auto-configure WakaTime API key in every container (~/.wakatime.cfg) */
+  WAKATIME_API_KEY?: string;
 }
 
 // ─── Container / Durable Object ──────────────────────────────────────────────
 
-/**
- * One CodeServerContainer instance = one isolated code-server per user.
- * Auth is handled by the Worker — the container runs with --auth none.
- */
 export class CodeServerContainer extends Container<Env> {
   defaultPort = 8080;
-  // Required so the container can reach R2's S3-compat HTTPS endpoint and github.com.
   enableInternet = true;
 
   constructor(ctx: DurableObjectState<SqlStorage>, env: Env) {
     super(ctx, env);
     this.sleepAfter = env.SLEEP_AFTER ?? "30m";
   }
-
-  // ── SQLite — store userId for R2 prefix ───────────────────────────────────
 
   private initSchema(): void {
     this.ctx.storage.sql.exec(`
@@ -81,8 +85,6 @@ export class CodeServerContainer extends Container<Env> {
     );
   }
 
-  // ── Lifecycle ──────────────────────────────────────────────────────────────
-
   override onStart(): void {
     console.log(`[code-server] started — ${this.ctx.id}`);
   }
@@ -95,12 +97,9 @@ export class CodeServerContainer extends Container<Env> {
     console.error(`[code-server] error:`, error);
   }
 
-  // ── Request handler ────────────────────────────────────────────────────────
-
   override async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
 
-    // ── Internal RPC: register userId (idempotent) ───────────────────────────
     if (url.pathname === "/__internal/init" && request.method === "POST") {
       const { userId } = (await request.json()) as { userId: string };
       this.initSchema();
@@ -108,13 +107,10 @@ export class CodeServerContainer extends Container<Env> {
       return Response.json({ ok: true });
     }
 
-    // ── Internal RPC: container state ────────────────────────────────────────
     if (url.pathname === "/__internal/state") {
-      const state = await this.getState();
-      return Response.json(state);
+      return Response.json(await this.getState());
     }
 
-    // ── Proxy to code-server ──────────────────────────────────────────────────
     this.renewActivityTimeout();
 
     const userId = this.getConfig("user_id") ?? "default";
@@ -127,6 +123,7 @@ export class CodeServerContainer extends Container<Env> {
       USER_ID: userId,
       GITHUB_REPOS: this.env.GITHUB_REPOS ?? "",
       GITHUB_TOKEN: this.env.GITHUB_TOKEN ?? "",
+      WAKATIME_API_KEY: this.env.WAKATIME_API_KEY ?? "",
     };
 
     return super.fetch(request);
@@ -139,24 +136,29 @@ function landingPage(env: Env): Response {
   const hasGoogleAuth = !!(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET);
   const hasCFAccess = !!(env.TEAM_DOMAIN && env.POLICY_AUD);
 
-  const signInButton = hasGoogleAuth
-    ? `<a class="btn-primary" href="/auth/login">Sign in with Google</a>`
+  const signInHref = hasGoogleAuth
+    ? "/auth/login"
     : hasCFAccess
-    ? `<a class="btn-primary" href="/">Sign in</a>`
-    : `<a class="btn-primary" href="/?user=dev">Open IDE (dev mode)</a>`;
+    ? "/"
+    : "/?user=dev";
+  const signInLabel = hasGoogleAuth
+    ? "Sign in with Google"
+    : hasCFAccess
+    ? "Sign in"
+    : "Open IDE (dev mode)";
 
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>Cloud IDE</title>
+  <title>Cloud IDE — VS Code for every developer</title>
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
     :root {
       --bg: #0d1117; --surface: #161b22; --border: #30363d;
       --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
-      --green: #238636; --green-h: #2ea043;
+      --green: #238636; --green-h: #2ea043; --purple: #a371f7;
     }
     body {
       font-family: system-ui, -apple-system, sans-serif;
@@ -167,55 +169,86 @@ function landingPage(env: Env): Response {
       padding: 1rem 2rem; border-bottom: 1px solid var(--border);
       display: flex; align-items: center; justify-content: space-between;
     }
-    .logo { font-size: 1rem; font-weight: 600; color: var(--text); text-decoration: none; }
+    .logo { font-size: 1rem; font-weight: 700; color: var(--text); text-decoration: none; }
     .logo span { color: var(--accent); }
-    main {
-      flex: 1; display: flex; flex-direction: column;
-      align-items: center; justify-content: center;
-      padding: 3rem 1.5rem; text-align: center;
-    }
-    .badge {
-      display: inline-block; background: #1f2937; border: 1px solid var(--border);
-      border-radius: 999px; padding: .25rem .875rem;
-      font-size: .75rem; color: var(--muted); letter-spacing: .03em; margin-bottom: 1.5rem;
+    .nav-action { font-size: .875rem; }
+    .nav-action a { color: var(--muted); text-decoration: none; }
+    .nav-action a:hover { color: var(--text); }
+    main { flex: 1; display: flex; flex-direction: column; align-items: center; padding: 0 1.5rem; }
+
+    /* ── Hero ── */
+    .hero { text-align: center; padding: 5rem 0 3.5rem; max-width: 640px; width: 100%; }
+    .hero-badge {
+      display: inline-block; background: #1a1f2e; border: 1px solid #2d3754;
+      border-radius: 999px; padding: .25rem 1rem;
+      font-size: .75rem; color: var(--accent); letter-spacing: .04em; margin-bottom: 1.5rem;
     }
     h1 {
-      font-size: clamp(2rem, 5vw, 3.25rem); font-weight: 700;
-      line-height: 1.15; margin-bottom: 1rem; letter-spacing: -.02em;
+      font-size: clamp(2.2rem, 5vw, 3.5rem); font-weight: 700;
+      line-height: 1.12; margin-bottom: 1.1rem; letter-spacing: -.03em;
     }
     h1 em { font-style: normal; color: var(--accent); }
-    .sub {
-      font-size: 1.1rem; color: var(--muted); max-width: 520px;
-      line-height: 1.65; margin-bottom: 2.5rem;
+    .hero-sub {
+      font-size: 1.1rem; color: var(--muted); line-height: 1.7; margin-bottom: 2.5rem;
     }
-    .actions { display: flex; gap: .75rem; flex-wrap: wrap; justify-content: center; }
+    .hero-actions { display: flex; gap: .75rem; flex-wrap: wrap; justify-content: center; }
     .btn-primary {
       background: var(--green); color: #fff; border-radius: 8px;
       padding: .7rem 1.75rem; text-decoration: none; font-size: .95rem; font-weight: 500;
-      transition: background .15s;
     }
     .btn-primary:hover { background: var(--green-h); }
     .btn-ghost {
       background: transparent; color: var(--muted); border: 1px solid var(--border);
       border-radius: 8px; padding: .7rem 1.75rem; text-decoration: none; font-size: .95rem;
-      transition: background .15s, color .15s;
     }
     .btn-ghost:hover { background: var(--surface); color: var(--text); }
-    .features {
-      display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+
+    /* ── Feature grid ── */
+    .section { width: 100%; max-width: 900px; padding: 2rem 0 3.5rem; }
+    .section-label {
+      font-size: .72rem; text-transform: uppercase; letter-spacing: .1em;
+      color: var(--muted); margin-bottom: 1.25rem;
+    }
+    .feature-grid {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(195px, 1fr));
       gap: 1px; background: var(--border);
-      border: 1px solid var(--border); border-radius: 12px;
-      overflow: hidden; max-width: 860px; width: 100%; margin-top: 4rem;
+      border: 1px solid var(--border); border-radius: 12px; overflow: hidden;
     }
     .feature {
-      background: var(--surface); padding: 1.5rem 1.25rem;
-      display: flex; flex-direction: column; gap: .5rem; text-align: left;
+      background: var(--surface); padding: 1.4rem 1.25rem;
+      display: flex; flex-direction: column; gap: .45rem;
     }
-    .feature-icon { font-size: 1.4rem; }
-    .feature-title { font-size: .9rem; font-weight: 600; }
-    .feature-desc { font-size: .8rem; color: var(--muted); line-height: 1.5; }
+    .fi { font-size: 1.35rem; }
+    .ft { font-size: .875rem; font-weight: 600; }
+    .fd { font-size: .78rem; color: var(--muted); line-height: 1.55; }
+
+    /* ── Teams CTA ── */
+    .teams-cta {
+      width: 100%; max-width: 900px;
+      background: linear-gradient(135deg, #161b22 0%, #1a1f2e 100%);
+      border: 1px solid #2d3754; border-radius: 14px;
+      padding: 2.5rem 2rem; margin-bottom: 4rem;
+      display: flex; gap: 2rem; align-items: center; flex-wrap: wrap;
+    }
+    .teams-cta-text { flex: 1; min-width: 220px; }
+    .teams-cta-text h2 { font-size: 1.4rem; margin-bottom: .5rem; }
+    .teams-cta-text p { color: var(--muted); font-size: .9rem; line-height: 1.6; }
+    .teams-cta-pills { display: flex; flex-direction: column; gap: .5rem; min-width: 220px; }
+    .pill {
+      display: flex; align-items: center; gap: .6rem;
+      font-size: .82rem; color: var(--muted);
+    }
+    .pill-dot { width: 6px; height: 6px; border-radius: 50%; background: var(--accent); flex-shrink: 0; }
+    .teams-cta-action { display: flex; flex-direction: column; gap: .75rem; align-items: flex-start; }
+    .btn-teams {
+      background: var(--purple); color: #fff; border-radius: 8px;
+      padding: .7rem 1.5rem; text-decoration: none; font-size: .9rem; font-weight: 500;
+      white-space: nowrap;
+    }
+    .btn-teams:hover { filter: brightness(1.1); }
+
     footer {
-      padding: 1.5rem 2rem; border-top: 1px solid var(--border);
+      border-top: 1px solid var(--border); padding: 1.5rem 2rem;
       text-align: center; font-size: .78rem; color: var(--muted);
     }
   </style>
@@ -223,65 +256,92 @@ function landingPage(env: Env): Response {
 <body>
   <nav>
     <a class="logo" href="/">Cloud <span>IDE</span></a>
+    <div class="nav-action"><a href="${signInHref}">${signInLabel}</a></div>
   </nav>
 
   <main>
-    <div class="badge">Powered by Cloudflare Containers</div>
-    <h1>Your personal<br><em>cloud IDE</em></h1>
-    <p class="sub">
-      A full VS Code environment that spins up in seconds,
-      persists your work to R2, and sleeps when you're away — so you pay only while coding.
-    </p>
-    <div class="actions">
-      ${signInButton}
-      <a class="btn-ghost" href="https://github.com/coder/code-server" target="_blank" rel="noopener">
-        Learn more
-      </a>
+    <!-- Hero -->
+    <section class="hero">
+      <div class="hero-badge">Powered by Cloudflare Containers</div>
+      <h1>The cloud IDE for<br><em>developer teams</em></h1>
+      <p class="hero-sub">
+        A full VS Code environment per developer — isolated, persistent, and
+        ready in seconds. Manage your whole team from one dashboard.
+      </p>
+      <div class="hero-actions">
+        <a class="btn-primary" href="${signInHref}">${signInLabel}</a>
+        <a class="btn-ghost" href="/admin">Team dashboard</a>
+      </div>
+    </section>
+
+    <!-- Developer features -->
+    <div class="section">
+      <div class="section-label">For developers</div>
+      <div class="feature-grid">
+        <div class="feature">
+          <div class="fi">📦</div>
+          <div class="ft">Isolated container per user</div>
+          <div class="fd">Your own VS Code — no shared state, no conflicts with teammates.</div>
+        </div>
+        <div class="feature">
+          <div class="fi">💾</div>
+          <div class="ft">Workspace persisted to R2</div>
+          <div class="fd">Files sync automatically to Cloudflare R2 via FUSE. Survive restarts.</div>
+        </div>
+        <div class="feature">
+          <div class="fi">🔄</div>
+          <div class="ft">GitHub repos auto-cloned</div>
+          <div class="fd">Configure repos once — they appear in your workspace on first boot.</div>
+        </div>
+        <div class="feature">
+          <div class="fi">🤖</div>
+          <div class="ft">Claude Code + Codex CLI</div>
+          <div class="fd">AI coding assistants pre-installed and ready in every terminal.</div>
+        </div>
+        <div class="feature">
+          <div class="fi">🔌</div>
+          <div class="ft">10+ extensions pre-installed</div>
+          <div class="fd">GitLens, ESLint, Prettier, Python, Tailwind, Error Lens, and more.</div>
+        </div>
+        <div class="feature">
+          <div class="fi">💤</div>
+          <div class="ft">Idle sleep</div>
+          <div class="fd">Containers hibernate after inactivity and wake instantly on return.</div>
+        </div>
+      </div>
     </div>
 
-    <div class="features">
-      <div class="feature">
-        <div class="feature-icon">📦</div>
-        <div class="feature-title">Isolated container per user</div>
-        <div class="feature-desc">Every user gets their own container — no shared state, no conflicts.</div>
+    <!-- Teams CTA -->
+    <div class="teams-cta">
+      <div class="teams-cta-text">
+        <h2>Built for engineering teams</h2>
+        <p>
+          Group your developers into teams, track coding time with
+          WakaTime, and onboard new members with a single invite link —
+          all from a central admin dashboard.
+        </p>
       </div>
-      <div class="feature">
-        <div class="feature-icon">💾</div>
-        <div class="feature-title">Workspace persisted to R2</div>
-        <div class="feature-desc">Files sync automatically to Cloudflare R2 via FUSE. Survive restarts.</div>
+      <div class="teams-cta-pills">
+        <div class="pill"><span class="pill-dot"></span>Team accounts with role-based access</div>
+        <div class="pill"><span class="pill-dot"></span>Admin dashboard to manage members</div>
+        <div class="pill"><span class="pill-dot"></span>Invite developers by email — 7-day links</div>
+        <div class="pill"><span class="pill-dot"></span>WakaTime time tracking pre-installed</div>
+        <div class="pill"><span class="pill-dot"></span>Per-member container status at a glance</div>
       </div>
-      <div class="feature">
-        <div class="feature-icon">🔄</div>
-        <div class="feature-title">GitHub repos auto-cloned</div>
-        <div class="feature-desc">Configure repos once — they appear in your workspace on first boot.</div>
-      </div>
-      <div class="feature">
-        <div class="feature-icon">🤖</div>
-        <div class="feature-title">Claude Code + Codex CLI</div>
-        <div class="feature-desc">AI coding assistants pre-installed and ready in every terminal.</div>
-      </div>
-      <div class="feature">
-        <div class="feature-icon">🔌</div>
-        <div class="feature-title">Extensions pre-installed</div>
-        <div class="feature-desc">GitLens, ESLint, Prettier, Python, Tailwind, and more — ready on launch.</div>
-      </div>
-      <div class="feature">
-        <div class="feature-icon">💤</div>
-        <div class="feature-title">Idle sleep — pay while coding</div>
-        <div class="feature-desc">Containers hibernate after inactivity and wake instantly on your return.</div>
+      <div class="teams-cta-action">
+        <a class="btn-teams" href="${signInHref}">Get started free</a>
+        <a class="btn-ghost" href="/admin" style="font-size:.85rem">Open dashboard</a>
       </div>
     </div>
   </main>
 
   <footer>
-    Built on Cloudflare Containers · code-server by Coder
+    Built on Cloudflare Containers · code-server by Coder · WakaTime time tracking
   </footer>
 </body>
 </html>`;
 
-  return new Response(html, {
-    headers: { "Content-Type": "text/html; charset=utf-8" },
-  });
+  return new Response(html, { headers: { "Content-Type": "text/html; charset=utf-8" } });
 }
 
 // ─── Worker entry point ───────────────────────────────────────────────────────
@@ -290,36 +350,32 @@ export default {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
-    // ── Health check (unauthenticated) ──────────────────────────────────────
     if (url.pathname === "/health") {
       return Response.json({ status: "ok", ts: Date.now() });
     }
 
-    // ── Google OAuth routes (login / callback / logout) ─────────────────────
     const authRouteResp = await handleAuthRoutes(request, env, url);
     if (authRouteResp) return authRouteResp;
 
-    // ── Authenticate ─────────────────────────────────────────────────────────
     const authResult = await authenticate(request, env);
 
-    // If not authenticated and Google OAuth is configured: show landing page
-    // for GET requests instead of bouncing straight to the login redirect.
     if (authResult instanceof Response) {
       const isGoogleOAuth = !!(env.GOOGLE_CLIENT_ID && !env.TEAM_DOMAIN);
-      if (isGoogleOAuth && request.method === "GET") {
-        return landingPage(env);
-      }
+      if (isGoogleOAuth && request.method === "GET") return landingPage(env);
       return authResult;
     }
 
     const { email, userId } = authResult;
 
-    // ── Route to the user's personal container ──────────────────────────────
+    // ── Admin / teams routes ─────────────────────────────────────────────────
+    const adminResp = await handleAdminRoutes(request, env, url, email, userId);
+    if (adminResp) return adminResp;
+
+    // ── User's own container ─────────────────────────────────────────────────
     const stub = env.CODE_SERVER.getByName(userId) as unknown as {
       fetch(req: Request): Promise<Response>;
     };
 
-    // Register userId in the DO (idempotent — one SQL upsert per request).
     await stub.fetch(
       new Request("http://internal/__internal/init", {
         method: "POST",
@@ -328,16 +384,11 @@ export default {
       })
     );
 
-    // ── /status — container state for debugging ──────────────────────────────
     if (url.pathname === "/status") {
-      const stateResp = await stub.fetch(
-        new Request("http://internal/__internal/state")
-      );
-      const state = await stateResp.json();
-      return Response.json({ userId, email, container: state });
+      const r = await stub.fetch(new Request("http://internal/__internal/state"));
+      return Response.json({ userId, email, container: await r.json() });
     }
 
-    // ── Proxy to code-server ─────────────────────────────────────────────────
     return stub.fetch(request);
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/vscode-cloud/src/index.ts
+++ b/apps/vscode-cloud/src/index.ts
@@ -8,39 +8,26 @@ export interface Env {
   CODE_SERVER: DurableObjectNamespace;
 
   // ── Cloudflare Access (production — option A) ─────────────────────────────
-  /** e.g. https://yourteam.cloudflareaccess.com  —  set via wrangler var */
   TEAM_DOMAIN?: string;
-  /** Application Audience tag from the Access dashboard — set via wrangler var */
   POLICY_AUD?: string;
 
   // ── Google OAuth (production — option B) ─────────────────────────────────
-  /** Google OAuth client ID — set via wrangler var */
   GOOGLE_CLIENT_ID?: string;
-  /** Google OAuth client secret — set via wrangler secret */
   GOOGLE_CLIENT_SECRET?: string;
-  /** KV namespace for storing Google OAuth sessions (7-day TTL) */
   SESSION_STORE?: KVNamespace;
 
   // ── Container behaviour ───────────────────────────────────────────────────
-  /** How long to keep container alive after last request. Default: 30m */
   SLEEP_AFTER: string;
 
   // ── R2 workspace storage ─────────────────────────────────────────────────
-  /** R2 bucket binding — used to verify the bucket exists at deploy time */
   WORKSPACE_BUCKET: R2Bucket;
-  /** R2 API token access key (wrangler secret) — passed to container for FUSE mount */
   R2_ACCESS_KEY_ID?: string;
-  /** R2 API token secret key (wrangler secret) — passed to container for FUSE mount */
   R2_SECRET_ACCESS_KEY?: string;
-  /** Cloudflare account ID (wrangler secret) — needed for the R2 S3-compat endpoint */
   R2_ACCOUNT_ID?: string;
-  /** R2 bucket name (wrangler var) */
   R2_BUCKET_NAME: string;
 
   // ── GitHub repo auto-cloning ──────────────────────────────────────────────
-  /** Comma-separated list of "owner/repo" pairs to clone on container start */
   GITHUB_REPOS?: string;
-  /** GitHub personal access token for private repos (wrangler secret) */
   GITHUB_TOKEN?: string;
 }
 
@@ -48,16 +35,11 @@ export interface Env {
 
 /**
  * One CodeServerContainer instance = one isolated code-server per user.
- *
- * Responsibilities:
- *  - Generate and persist a cryptographically random password per user in SQLite.
- *  - Inject that password + R2/GitHub credentials as env vars on container start.
- *  - Expose internal RPC endpoints for the Worker (init, password, reset).
- *  - Forward all other requests to code-server, renewing the idle timer each time.
+ * Auth is handled by the Worker — the container runs with --auth none.
  */
 export class CodeServerContainer extends Container<Env> {
   defaultPort = 8080;
-  // Containers need internet to reach R2's HTTPS endpoint and github.com for cloning.
+  // Required so the container can reach R2's S3-compat HTTPS endpoint and github.com.
   enableInternet = true;
 
   constructor(ctx: DurableObjectState<SqlStorage>, env: Env) {
@@ -65,7 +47,7 @@ export class CodeServerContainer extends Container<Env> {
     this.sleepAfter = env.SLEEP_AFTER ?? "30m";
   }
 
-  // ── SQLite helpers ─────────────────────────────────────────────────────────
+  // ── SQLite — store userId for R2 prefix ───────────────────────────────────
 
   private initSchema(): void {
     this.ctx.storage.sql.exec(`
@@ -86,7 +68,6 @@ export class CodeServerContainer extends Container<Env> {
       ];
       return rows.length > 0 ? (rows[0].value as string) : null;
     } catch {
-      // Table doesn't exist yet — return null so callers fall back to defaults.
       return null;
     }
   }
@@ -100,39 +81,18 @@ export class CodeServerContainer extends Container<Env> {
     );
   }
 
-  /**
-   * Return the user's password, generating a secure random one on first call.
-   * Uses base-62 chars (A-Z a-z 0-9) so it's safe for shell env vars and URLs.
-   */
-  private getOrCreatePassword(): string {
-    this.initSchema();
-
-    const stored = this.getConfig("password");
-    if (stored) return stored;
-
-    const chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-    const bytes = new Uint8Array(24);
-    crypto.getRandomValues(bytes);
-    const password = Array.from(bytes)
-      .map((b) => chars[b % chars.length])
-      .join("");
-
-    this.setConfig("password", password);
-    return password;
-  }
-
-  // ── Lifecycle hooks ────────────────────────────────────────────────────────
+  // ── Lifecycle ──────────────────────────────────────────────────────────────
 
   override onStart(): void {
-    console.log(`[code-server] Container started — DO id: ${this.ctx.id}`);
+    console.log(`[code-server] started — ${this.ctx.id}`);
   }
 
   override onStop(_: StopParams): void {
-    console.log(`[code-server] Container stopped — DO id: ${this.ctx.id}`);
+    console.log(`[code-server] stopped — ${this.ctx.id}`);
   }
 
   override onError(error: unknown): void {
-    console.error(`[code-server] Container error:`, error);
+    console.error(`[code-server] error:`, error);
   }
 
   // ── Request handler ────────────────────────────────────────────────────────
@@ -140,7 +100,7 @@ export class CodeServerContainer extends Container<Env> {
   override async fetch(request: Request): Promise<Response> {
     const url = new URL(request.url);
 
-    // ── Internal RPC: register userId for this DO (idempotent) ───────────────
+    // ── Internal RPC: register userId (idempotent) ───────────────────────────
     if (url.pathname === "/__internal/init" && request.method === "POST") {
       const { userId } = (await request.json()) as { userId: string };
       this.initSchema();
@@ -148,35 +108,18 @@ export class CodeServerContainer extends Container<Env> {
       return Response.json({ ok: true });
     }
 
-    // ── Internal RPC: retrieve the current password ───────────────────────────
-    if (url.pathname === "/__internal/password") {
-      return Response.json({ password: this.getOrCreatePassword() });
-    }
-
-    // ── Internal RPC: reset password and restart container ────────────────────
-    if (url.pathname === "/__internal/reset-password" && request.method === "POST") {
-      this.initSchema();
-      this.ctx.storage.sql.exec("DELETE FROM user_config WHERE key = 'password'");
-      try { await this.stop(); } catch { /* already stopped */ }
-      return Response.json({ ok: true });
-    }
-
-    // ── Internal RPC: container health / state ────────────────────────────────
+    // ── Internal RPC: container state ────────────────────────────────────────
     if (url.pathname === "/__internal/state") {
       const state = await this.getState();
       return Response.json(state);
     }
 
     // ── Proxy to code-server ──────────────────────────────────────────────────
-    // Renew idle timer on every proxied request so an active browser session
-    // keeps the container alive even if sleepAfter would fire.
     this.renewActivityTimeout();
 
     const userId = this.getConfig("user_id") ?? "default";
-    const password = this.getOrCreatePassword();
 
     this.envVars = {
-      PASSWORD: password,
       R2_ACCESS_KEY_ID: this.env.R2_ACCESS_KEY_ID ?? "",
       R2_SECRET_ACCESS_KEY: this.env.R2_SECRET_ACCESS_KEY ?? "",
       R2_ACCOUNT_ID: this.env.R2_ACCOUNT_ID ?? "",
@@ -190,92 +133,158 @@ export class CodeServerContainer extends Container<Env> {
   }
 }
 
-// ─── Worker entry point ───────────────────────────────────────────────────────
+// ─── Landing page ─────────────────────────────────────────────────────────────
 
-function setupPage(email: string, password: string, sleepAfter: string): Response {
+function landingPage(env: Env): Response {
+  const hasGoogleAuth = !!(env.GOOGLE_CLIENT_ID && env.GOOGLE_CLIENT_SECRET);
+  const hasCFAccess = !!(env.TEAM_DOMAIN && env.POLICY_AUD);
+
+  const signInButton = hasGoogleAuth
+    ? `<a class="btn-primary" href="/auth/login">Sign in with Google</a>`
+    : hasCFAccess
+    ? `<a class="btn-primary" href="/">Sign in</a>`
+    : `<a class="btn-primary" href="/?user=dev">Open IDE (dev mode)</a>`;
+
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>code-server — setup</title>
+  <title>Cloud IDE</title>
   <style>
-    *{box-sizing:border-box}
-    body{font-family:system-ui,sans-serif;background:#0d1117;color:#e6edf3;
-         display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
-    .card{background:#161b22;border:1px solid #30363d;border-radius:12px;
-          padding:2rem 2.5rem;max-width:480px;width:100%}
-    h1{margin:0 0 .25rem;font-size:1.25rem}
-    .sub{color:#8b949e;margin:0 0 1.75rem;font-size:.9rem}
-    .label{font-size:.75rem;color:#8b949e;text-transform:uppercase;letter-spacing:.05em;margin-bottom:.4rem}
-    .pw{font-family:monospace;font-size:1.1rem;background:#0d1117;border:1px solid #30363d;
-        border-radius:6px;padding:.6rem 1rem;letter-spacing:.08em;color:#58a6ff;user-select:all;
-        display:flex;justify-content:space-between;align-items:center;gap:.5rem}
-    .pw span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
-    .copy-btn{background:#21262d;border:1px solid #30363d;color:#e6edf3;border-radius:4px;
-              padding:.2rem .6rem;font-size:.75rem;cursor:pointer;white-space:nowrap;flex-shrink:0}
-    .copy-btn:hover{background:#30363d}
-    .note{margin-top:1rem;font-size:.82rem;color:#8b949e;line-height:1.5}
-    .actions{display:flex;gap:.75rem;margin-top:1.5rem;flex-wrap:wrap}
-    .btn{display:inline-flex;align-items:center;background:#238636;color:#fff;border-radius:6px;
-         padding:.55rem 1.25rem;text-decoration:none;font-size:.9rem;border:none;cursor:pointer}
-    .btn:hover{background:#2ea043}
-    .btn-ghost{background:transparent;border:1px solid #30363d;color:#e6edf3}
-    .btn-ghost:hover{background:#21262d}
-    .badge{display:inline-block;background:#21262d;border:1px solid #30363d;border-radius:4px;
-           padding:.15rem .5rem;font-size:.75rem;color:#8b949e;margin-left:.5rem}
-    .logout{float:right;font-size:.8rem;color:#8b949e;text-decoration:none}
-    .logout:hover{color:#e6edf3}
-    hr{border:none;border-top:1px solid #21262d;margin:1.5rem 0}
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg: #0d1117; --surface: #161b22; --border: #30363d;
+      --text: #e6edf3; --muted: #8b949e; --accent: #58a6ff;
+      --green: #238636; --green-h: #2ea043;
+    }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      background: var(--bg); color: var(--text);
+      min-height: 100vh; display: flex; flex-direction: column;
+    }
+    nav {
+      padding: 1rem 2rem; border-bottom: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between;
+    }
+    .logo { font-size: 1rem; font-weight: 600; color: var(--text); text-decoration: none; }
+    .logo span { color: var(--accent); }
+    main {
+      flex: 1; display: flex; flex-direction: column;
+      align-items: center; justify-content: center;
+      padding: 3rem 1.5rem; text-align: center;
+    }
+    .badge {
+      display: inline-block; background: #1f2937; border: 1px solid var(--border);
+      border-radius: 999px; padding: .25rem .875rem;
+      font-size: .75rem; color: var(--muted); letter-spacing: .03em; margin-bottom: 1.5rem;
+    }
+    h1 {
+      font-size: clamp(2rem, 5vw, 3.25rem); font-weight: 700;
+      line-height: 1.15; margin-bottom: 1rem; letter-spacing: -.02em;
+    }
+    h1 em { font-style: normal; color: var(--accent); }
+    .sub {
+      font-size: 1.1rem; color: var(--muted); max-width: 520px;
+      line-height: 1.65; margin-bottom: 2.5rem;
+    }
+    .actions { display: flex; gap: .75rem; flex-wrap: wrap; justify-content: center; }
+    .btn-primary {
+      background: var(--green); color: #fff; border-radius: 8px;
+      padding: .7rem 1.75rem; text-decoration: none; font-size: .95rem; font-weight: 500;
+      transition: background .15s;
+    }
+    .btn-primary:hover { background: var(--green-h); }
+    .btn-ghost {
+      background: transparent; color: var(--muted); border: 1px solid var(--border);
+      border-radius: 8px; padding: .7rem 1.75rem; text-decoration: none; font-size: .95rem;
+      transition: background .15s, color .15s;
+    }
+    .btn-ghost:hover { background: var(--surface); color: var(--text); }
+    .features {
+      display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 1px; background: var(--border);
+      border: 1px solid var(--border); border-radius: 12px;
+      overflow: hidden; max-width: 860px; width: 100%; margin-top: 4rem;
+    }
+    .feature {
+      background: var(--surface); padding: 1.5rem 1.25rem;
+      display: flex; flex-direction: column; gap: .5rem; text-align: left;
+    }
+    .feature-icon { font-size: 1.4rem; }
+    .feature-title { font-size: .9rem; font-weight: 600; }
+    .feature-desc { font-size: .8rem; color: var(--muted); line-height: 1.5; }
+    footer {
+      padding: 1.5rem 2rem; border-top: 1px solid var(--border);
+      text-align: center; font-size: .78rem; color: var(--muted);
+    }
   </style>
 </head>
 <body>
-  <div class="card">
-    <a class="logout" href="/auth/logout">Sign out</a>
-    <h1>Your cloud IDE is ready <span class="badge">starting…</span></h1>
-    <p class="sub">Signed in as <strong>${email}</strong></p>
+  <nav>
+    <a class="logo" href="/">Cloud <span>IDE</span></a>
+  </nav>
 
-    <div class="label">Your unique password</div>
-    <div class="pw">
-      <span id="pw">${password}</span>
-      <button class="copy-btn" onclick="copyPw()">Copy</button>
-    </div>
-    <p class="note">
-      This password is unique to you — it never changes unless you request a reset.
-      The IDE sleeps after <strong>${sleepAfter}</strong> of inactivity to save cost
-      and wakes automatically on your next visit.
+  <main>
+    <div class="badge">Powered by Cloudflare Containers</div>
+    <h1>Your personal<br><em>cloud IDE</em></h1>
+    <p class="sub">
+      A full VS Code environment that spins up in seconds,
+      persists your work to R2, and sleeps when you're away — so you pay only while coding.
     </p>
-
     <div class="actions">
-      <a class="btn" href="/" onclick="navigator.clipboard?.writeText('${password}')">
-        Copy &amp; open IDE &rarr;
+      ${signInButton}
+      <a class="btn-ghost" href="https://github.com/coder/code-server" target="_blank" rel="noopener">
+        Learn more
       </a>
-      <form method="POST" action="/reset-password" style="margin:0">
-        <button type="submit" class="btn btn-ghost">Reset password</button>
-      </form>
     </div>
 
-    <hr>
-    <p class="note" style="margin:0">
-      <strong>GitHub repos</strong> configured for auto-clone are loaded into
-      <code>/home/coder/workspace/</code> on first boot. Workspace changes sync
-      automatically to R2 via FUSE.
-    </p>
-  </div>
-  <script>
-    function copyPw() {
-      navigator.clipboard?.writeText(document.getElementById('pw').textContent ?? '');
-      const btn = document.querySelector('.copy-btn');
-      btn.textContent = 'Copied!';
-      setTimeout(() => btn.textContent = 'Copy', 1500);
-    }
-  </script>
+    <div class="features">
+      <div class="feature">
+        <div class="feature-icon">📦</div>
+        <div class="feature-title">Isolated container per user</div>
+        <div class="feature-desc">Every user gets their own container — no shared state, no conflicts.</div>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">💾</div>
+        <div class="feature-title">Workspace persisted to R2</div>
+        <div class="feature-desc">Files sync automatically to Cloudflare R2 via FUSE. Survive restarts.</div>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">🔄</div>
+        <div class="feature-title">GitHub repos auto-cloned</div>
+        <div class="feature-desc">Configure repos once — they appear in your workspace on first boot.</div>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">🤖</div>
+        <div class="feature-title">Claude Code + Codex CLI</div>
+        <div class="feature-desc">AI coding assistants pre-installed and ready in every terminal.</div>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">🔌</div>
+        <div class="feature-title">Extensions pre-installed</div>
+        <div class="feature-desc">GitLens, ESLint, Prettier, Python, Tailwind, and more — ready on launch.</div>
+      </div>
+      <div class="feature">
+        <div class="feature-icon">💤</div>
+        <div class="feature-title">Idle sleep — pay while coding</div>
+        <div class="feature-desc">Containers hibernate after inactivity and wake instantly on your return.</div>
+      </div>
+    </div>
+  </main>
+
+  <footer>
+    Built on Cloudflare Containers · code-server by Coder
+  </footer>
 </body>
 </html>`;
+
   return new Response(html, {
     headers: { "Content-Type": "text/html; charset=utf-8" },
   });
 }
+
+// ─── Worker entry point ───────────────────────────────────────────────────────
 
 export default {
   async fetch(request: Request, env: Env): Promise<Response> {
@@ -287,23 +296,30 @@ export default {
     }
 
     // ── Google OAuth routes (login / callback / logout) ─────────────────────
-    // Must run before authenticate() so unauthenticated users can reach /auth/login
     const authRouteResp = await handleAuthRoutes(request, env, url);
     if (authRouteResp) return authRouteResp;
 
-    // ── Authenticate via CF Access JWT, Google session, or dev header ────────
+    // ── Authenticate ─────────────────────────────────────────────────────────
     const authResult = await authenticate(request, env);
-    if (authResult instanceof Response) return authResult;
+
+    // If not authenticated and Google OAuth is configured: show landing page
+    // for GET requests instead of bouncing straight to the login redirect.
+    if (authResult instanceof Response) {
+      const isGoogleOAuth = !!(env.GOOGLE_CLIENT_ID && !env.TEAM_DOMAIN);
+      if (isGoogleOAuth && request.method === "GET") {
+        return landingPage(env);
+      }
+      return authResult;
+    }
 
     const { email, userId } = authResult;
 
-    // ── Route to the user's personal container instance ─────────────────────
+    // ── Route to the user's personal container ──────────────────────────────
     const stub = env.CODE_SERVER.getByName(userId) as unknown as {
       fetch(req: Request): Promise<Response>;
     };
 
-    // Register userId in the DO's SQLite so it can build the R2 prefix.
-    // This is idempotent and cheap (a single SQL upsert).
+    // Register userId in the DO (idempotent — one SQL upsert per request).
     await stub.fetch(
       new Request("http://internal/__internal/init", {
         method: "POST",
@@ -312,26 +328,7 @@ export default {
       })
     );
 
-    // ── /setup — password reveal + first-visit instructions ──────────────────
-    if (url.pathname === "/setup") {
-      const pwResp = await stub.fetch(
-        new Request("http://internal/__internal/password")
-      );
-      const { password } = (await pwResp.json()) as { password: string };
-      return setupPage(email, password, env.SLEEP_AFTER ?? "30m");
-    }
-
-    // ── /reset-password — regenerate password (POST only) ───────────────────
-    if (url.pathname === "/reset-password" && request.method === "POST") {
-      await stub.fetch(
-        new Request("http://internal/__internal/reset-password", {
-          method: "POST",
-        })
-      );
-      return Response.redirect(new URL("/setup", url).toString(), 303);
-    }
-
-    // ── /status — container state (JSON) ────────────────────────────────────
+    // ── /status — container state for debugging ──────────────────────────────
     if (url.pathname === "/status") {
       const stateResp = await stub.fetch(
         new Request("http://internal/__internal/state")
@@ -340,7 +337,7 @@ export default {
       return Response.json({ userId, email, container: state });
     }
 
-    // ── Proxy everything else to code-server ─────────────────────────────────
+    // ── Proxy to code-server ─────────────────────────────────────────────────
     return stub.fetch(request);
   },
 } satisfies ExportedHandler<Env>;

--- a/apps/vscode-cloud/src/index.ts
+++ b/apps/vscode-cloud/src/index.ts
@@ -1,4 +1,5 @@
 import { Container } from "@cloudflare/containers";
+import type { StopParams } from "@cloudflare/containers";
 import { authenticate, handleAuthRoutes } from "./auth";
 
 // ─── Env ─────────────────────────────────────────────────────────────────────
@@ -56,9 +57,11 @@ export interface Env {
  */
 export class CodeServerContainer extends Container<Env> {
   defaultPort = 8080;
+  // Containers need internet to reach R2's HTTPS endpoint and github.com for cloning.
+  enableInternet = true;
 
-  constructor(ctx: DurableObjectState<unknown>, env: Env) {
-    super(ctx as DurableObjectState<{}>, env);
+  constructor(ctx: DurableObjectState<SqlStorage>, env: Env) {
+    super(ctx, env);
     this.sleepAfter = env.SLEEP_AFTER ?? "30m";
   }
 
@@ -74,13 +77,18 @@ export class CodeServerContainer extends Container<Env> {
   }
 
   private getConfig(key: string): string | null {
-    const rows = [
-      ...this.ctx.storage.sql.exec(
-        "SELECT value FROM user_config WHERE key = ?",
-        key
-      ),
-    ];
-    return rows.length > 0 ? (rows[0].value as string) : null;
+    try {
+      const rows = [
+        ...this.ctx.storage.sql.exec(
+          "SELECT value FROM user_config WHERE key = ?",
+          key
+        ),
+      ];
+      return rows.length > 0 ? (rows[0].value as string) : null;
+    } catch {
+      // Table doesn't exist yet — return null so callers fall back to defaults.
+      return null;
+    }
   }
 
   private setConfig(key: string, value: string): void {
@@ -119,7 +127,7 @@ export class CodeServerContainer extends Container<Env> {
     console.log(`[code-server] Container started — DO id: ${this.ctx.id}`);
   }
 
-  override onStop(_: { exitCode: number; reason: string }): void {
+  override onStop(_: StopParams): void {
     console.log(`[code-server] Container stopped — DO id: ${this.ctx.id}`);
   }
 
@@ -153,10 +161,16 @@ export class CodeServerContainer extends Container<Env> {
       return Response.json({ ok: true });
     }
 
+    // ── Internal RPC: container health / state ────────────────────────────────
+    if (url.pathname === "/__internal/state") {
+      const state = await this.getState();
+      return Response.json(state);
+    }
+
     // ── Proxy to code-server ──────────────────────────────────────────────────
     // Renew idle timer on every proxied request so an active browser session
-    // keeps the container alive even if wrangler's sleepAfter would fire.
-    (this as unknown as { renewActivityTimeout?: () => void }).renewActivityTimeout?.();
+    // keeps the container alive even if sleepAfter would fire.
+    this.renewActivityTimeout();
 
     const userId = this.getConfig("user_id") ?? "default";
     const password = this.getOrCreatePassword();
@@ -178,47 +192,84 @@ export class CodeServerContainer extends Container<Env> {
 
 // ─── Worker entry point ───────────────────────────────────────────────────────
 
-function firstVisitPage(email: string, password: string): Response {
+function setupPage(email: string, password: string, sleepAfter: string): Response {
   const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>code-server — your password</title>
+  <title>code-server — setup</title>
   <style>
+    *{box-sizing:border-box}
     body{font-family:system-ui,sans-serif;background:#0d1117;color:#e6edf3;
          display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0}
     .card{background:#161b22;border:1px solid #30363d;border-radius:12px;
-          padding:2rem 2.5rem;max-width:460px;width:100%}
+          padding:2rem 2.5rem;max-width:480px;width:100%}
     h1{margin:0 0 .25rem;font-size:1.25rem}
-    p{color:#8b949e;margin:0 0 1.5rem;font-size:.9rem}
+    .sub{color:#8b949e;margin:0 0 1.75rem;font-size:.9rem}
     .label{font-size:.75rem;color:#8b949e;text-transform:uppercase;letter-spacing:.05em;margin-bottom:.4rem}
-    .pw{font-family:monospace;font-size:1.15rem;background:#0d1117;border:1px solid #30363d;
-        border-radius:6px;padding:.6rem 1rem;letter-spacing:.1em;color:#58a6ff;user-select:all}
-    .note{margin-top:1.25rem;font-size:.82rem;color:#8b949e}
-    .btn{display:inline-block;margin-top:1.5rem;background:#238636;color:#fff;border-radius:6px;
-         padding:.55rem 1.25rem;text-decoration:none;font-size:.9rem}
+    .pw{font-family:monospace;font-size:1.1rem;background:#0d1117;border:1px solid #30363d;
+        border-radius:6px;padding:.6rem 1rem;letter-spacing:.08em;color:#58a6ff;user-select:all;
+        display:flex;justify-content:space-between;align-items:center;gap:.5rem}
+    .pw span{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .copy-btn{background:#21262d;border:1px solid #30363d;color:#e6edf3;border-radius:4px;
+              padding:.2rem .6rem;font-size:.75rem;cursor:pointer;white-space:nowrap;flex-shrink:0}
+    .copy-btn:hover{background:#30363d}
+    .note{margin-top:1rem;font-size:.82rem;color:#8b949e;line-height:1.5}
+    .actions{display:flex;gap:.75rem;margin-top:1.5rem;flex-wrap:wrap}
+    .btn{display:inline-flex;align-items:center;background:#238636;color:#fff;border-radius:6px;
+         padding:.55rem 1.25rem;text-decoration:none;font-size:.9rem;border:none;cursor:pointer}
     .btn:hover{background:#2ea043}
-    .logout{float:right;font-size:.8rem;color:#8b949e;text-decoration:none;margin-top:.25rem}
+    .btn-ghost{background:transparent;border:1px solid #30363d;color:#e6edf3}
+    .btn-ghost:hover{background:#21262d}
+    .badge{display:inline-block;background:#21262d;border:1px solid #30363d;border-radius:4px;
+           padding:.15rem .5rem;font-size:.75rem;color:#8b949e;margin-left:.5rem}
+    .logout{float:right;font-size:.8rem;color:#8b949e;text-decoration:none}
     .logout:hover{color:#e6edf3}
+    hr{border:none;border-top:1px solid #21262d;margin:1.5rem 0}
   </style>
 </head>
 <body>
   <div class="card">
     <a class="logout" href="/auth/logout">Sign out</a>
-    <h1>Your cloud IDE is starting</h1>
-    <p>Signed in as <strong>${email}</strong></p>
+    <h1>Your cloud IDE is ready <span class="badge">starting…</span></h1>
+    <p class="sub">Signed in as <strong>${email}</strong></p>
+
     <div class="label">Your unique password</div>
-    <div class="pw" id="pw">${password}</div>
+    <div class="pw">
+      <span id="pw">${password}</span>
+      <button class="copy-btn" onclick="copyPw()">Copy</button>
+    </div>
     <p class="note">
-      This password is unique to you and stored securely — it never changes unless
-      you request a reset at <code>/reset-password</code>.
-      Copy it before clicking below.
+      This password is unique to you — it never changes unless you request a reset.
+      The IDE sleeps after <strong>${sleepAfter}</strong> of inactivity to save cost
+      and wakes automatically on your next visit.
     </p>
-    <a class="btn" href="/" onclick="navigator.clipboard?.writeText('${password}')">
-      Copy &amp; open code-server &rarr;
-    </a>
+
+    <div class="actions">
+      <a class="btn" href="/" onclick="navigator.clipboard?.writeText('${password}')">
+        Copy &amp; open IDE &rarr;
+      </a>
+      <form method="POST" action="/reset-password" style="margin:0">
+        <button type="submit" class="btn btn-ghost">Reset password</button>
+      </form>
+    </div>
+
+    <hr>
+    <p class="note" style="margin:0">
+      <strong>GitHub repos</strong> configured for auto-clone are loaded into
+      <code>/home/coder/workspace/</code> on first boot. Workspace changes sync
+      automatically to R2 via FUSE.
+    </p>
   </div>
+  <script>
+    function copyPw() {
+      navigator.clipboard?.writeText(document.getElementById('pw').textContent ?? '');
+      const btn = document.querySelector('.copy-btn');
+      btn.textContent = 'Copied!';
+      setTimeout(() => btn.textContent = 'Copy', 1500);
+    }
+  </script>
 </body>
 </html>`;
   return new Response(html, {
@@ -252,6 +303,7 @@ export default {
     };
 
     // Register userId in the DO's SQLite so it can build the R2 prefix.
+    // This is idempotent and cheap (a single SQL upsert).
     await stub.fetch(
       new Request("http://internal/__internal/init", {
         method: "POST",
@@ -260,13 +312,13 @@ export default {
       })
     );
 
-    // ── /setup — first-visit password reveal page ────────────────────────────
+    // ── /setup — password reveal + first-visit instructions ──────────────────
     if (url.pathname === "/setup") {
       const pwResp = await stub.fetch(
         new Request("http://internal/__internal/password")
       );
       const { password } = (await pwResp.json()) as { password: string };
-      return firstVisitPage(email, password);
+      return setupPage(email, password, env.SLEEP_AFTER ?? "30m");
     }
 
     // ── /reset-password — regenerate password (POST only) ───────────────────
@@ -277,6 +329,15 @@ export default {
         })
       );
       return Response.redirect(new URL("/setup", url).toString(), 303);
+    }
+
+    // ── /status — container state (JSON) ────────────────────────────────────
+    if (url.pathname === "/status") {
+      const stateResp = await stub.fetch(
+        new Request("http://internal/__internal/state")
+      );
+      const state = await stateResp.json();
+      return Response.json({ userId, email, container: state });
     }
 
     // ── Proxy everything else to code-server ─────────────────────────────────

--- a/apps/vscode-cloud/src/teams.ts
+++ b/apps/vscode-cloud/src/teams.ts
@@ -1,0 +1,183 @@
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface Team {
+  id: string;
+  name: string;
+  created_by: string;
+  created_at: number;
+}
+
+export interface TeamMember {
+  team_id: string;
+  user_id: string;
+  email: string;
+  role: "admin" | "member";
+  joined_at: number;
+}
+
+export interface TeamInvite {
+  token: string;
+  team_id: string;
+  email: string;
+  invited_by: string;
+  created_at: number;
+  expires_at: number;
+}
+
+// ─── Schema ───────────────────────────────────────────────────────────────────
+
+export async function initTeamsSchema(db: D1Database): Promise<void> {
+  await db.batch([
+    db.prepare(`CREATE TABLE IF NOT EXISTS teams (
+      id          TEXT PRIMARY KEY,
+      name        TEXT NOT NULL,
+      created_by  TEXT NOT NULL,
+      created_at  INTEGER NOT NULL
+    )`),
+    db.prepare(`CREATE TABLE IF NOT EXISTS team_members (
+      team_id    TEXT NOT NULL,
+      user_id    TEXT NOT NULL,
+      email      TEXT NOT NULL,
+      role       TEXT NOT NULL DEFAULT 'member',
+      joined_at  INTEGER NOT NULL,
+      PRIMARY KEY (team_id, user_id)
+    )`),
+    db.prepare(`CREATE TABLE IF NOT EXISTS team_invites (
+      token       TEXT PRIMARY KEY,
+      team_id     TEXT NOT NULL,
+      email       TEXT NOT NULL,
+      invited_by  TEXT NOT NULL,
+      created_at  INTEGER NOT NULL,
+      expires_at  INTEGER NOT NULL
+    )`),
+  ]);
+}
+
+// ─── Teams ────────────────────────────────────────────────────────────────────
+
+export async function createTeam(
+  db: D1Database,
+  name: string,
+  creatorId: string,
+  creatorEmail: string
+): Promise<Team> {
+  const id = crypto.randomUUID();
+  const now = Date.now();
+  await db.batch([
+    db.prepare(`INSERT INTO teams (id, name, created_by, created_at) VALUES (?, ?, ?, ?)`)
+      .bind(id, name, creatorId, now),
+    db.prepare(
+      `INSERT INTO team_members (team_id, user_id, email, role, joined_at) VALUES (?, ?, ?, 'admin', ?)`
+    ).bind(id, creatorId, creatorEmail, now),
+  ]);
+  return { id, name, created_by: creatorId, created_at: now };
+}
+
+export async function getAllTeams(db: D1Database): Promise<Team[]> {
+  const r = await db.prepare(`SELECT * FROM teams ORDER BY created_at DESC`).all<Team>();
+  return r.results;
+}
+
+export async function getTeamsByUser(db: D1Database, userId: string): Promise<Team[]> {
+  const r = await db
+    .prepare(
+      `SELECT t.* FROM teams t
+       JOIN team_members m ON t.id = m.team_id
+       WHERE m.user_id = ?
+       ORDER BY t.created_at DESC`
+    )
+    .bind(userId)
+    .all<Team>();
+  return r.results;
+}
+
+export async function getTeam(db: D1Database, id: string): Promise<Team | null> {
+  return db.prepare(`SELECT * FROM teams WHERE id = ?`).bind(id).first<Team>();
+}
+
+// ─── Members ──────────────────────────────────────────────────────────────────
+
+export async function getTeamMembers(db: D1Database, teamId: string): Promise<TeamMember[]> {
+  const r = await db
+    .prepare(`SELECT * FROM team_members WHERE team_id = ? ORDER BY joined_at ASC`)
+    .bind(teamId)
+    .all<TeamMember>();
+  return r.results;
+}
+
+export async function getMemberRole(
+  db: D1Database,
+  teamId: string,
+  userId: string
+): Promise<"admin" | "member" | null> {
+  const row = await db
+    .prepare(`SELECT role FROM team_members WHERE team_id = ? AND user_id = ?`)
+    .bind(teamId, userId)
+    .first<{ role: string }>();
+  return (row?.role as "admin" | "member") ?? null;
+}
+
+export async function addMember(
+  db: D1Database,
+  teamId: string,
+  userId: string,
+  email: string,
+  role: "admin" | "member" = "member"
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO team_members (team_id, user_id, email, role, joined_at) VALUES (?, ?, ?, ?, ?)
+       ON CONFLICT(team_id, user_id) DO NOTHING`
+    )
+    .bind(teamId, userId, email, role, Date.now())
+    .run();
+}
+
+export async function removeMember(
+  db: D1Database,
+  teamId: string,
+  userId: string
+): Promise<void> {
+  await db
+    .prepare(`DELETE FROM team_members WHERE team_id = ? AND user_id = ?`)
+    .bind(teamId, userId)
+    .run();
+}
+
+// ─── Invites ──────────────────────────────────────────────────────────────────
+
+export async function createInvite(
+  db: D1Database,
+  teamId: string,
+  email: string,
+  invitedBy: string
+): Promise<string> {
+  const token = crypto.randomUUID();
+  const now = Date.now();
+  await db
+    .prepare(
+      `INSERT INTO team_invites (token, team_id, email, invited_by, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?)`
+    )
+    .bind(token, teamId, email, invitedBy, now, now + 7 * 24 * 60 * 60 * 1000)
+    .run();
+  return token;
+}
+
+export async function getInvite(db: D1Database, token: string): Promise<TeamInvite | null> {
+  return db.prepare(`SELECT * FROM team_invites WHERE token = ?`).bind(token).first<TeamInvite>();
+}
+
+export async function getPendingInvites(db: D1Database, teamId: string): Promise<TeamInvite[]> {
+  const r = await db
+    .prepare(
+      `SELECT * FROM team_invites WHERE team_id = ? AND expires_at > ? ORDER BY created_at DESC`
+    )
+    .bind(teamId, Date.now())
+    .all<TeamInvite>();
+  return r.results;
+}
+
+export async function deleteInvite(db: D1Database, token: string): Promise<void> {
+  await db.prepare(`DELETE FROM team_invites WHERE token = ?`).bind(token).run();
+}

--- a/apps/vscode-cloud/wrangler.jsonc
+++ b/apps/vscode-cloud/wrangler.jsonc
@@ -90,6 +90,9 @@
   ],
 
   // ── Secrets (set via CLI, never committed) ────────────────────────────────
+  // Auth is handled by the Worker — code-server runs with --auth none.
+  // The container is only reachable through the authenticated Worker proxy.
+  //
   // R2 credentials for FUSE mount (geesefs inside the container):
   //   wrangler secret put R2_ACCESS_KEY_ID
   //   wrangler secret put R2_SECRET_ACCESS_KEY

--- a/apps/vscode-cloud/wrangler.jsonc
+++ b/apps/vscode-cloud/wrangler.jsonc
@@ -39,6 +39,17 @@
     },
   ],
 
+  // ── D1 database — teams, members, invites ────────────────────────────────
+  // Create with: wrangler d1 create vscode-cloud-teams
+  // Then paste the returned database_id below.
+  "d1_databases": [
+    {
+      "binding": "TEAMS_DB",
+      "database_name": "vscode-cloud-teams",
+      "database_id": "",  // paste the ID returned by `wrangler d1 create vscode-cloud-teams`
+    },
+  ],
+
   // ── KV namespace — Google OAuth sessions ─────────────────────────────────
   // Only needed when using Google OAuth (option B auth).
   // Create with: wrangler kv namespace create SESSION_STORE
@@ -73,6 +84,17 @@
     // ── R2 bucket name ────────────────────────────────────────────────────────
     "R2_BUCKET_NAME": "vscode-cloud-workspaces",
 
+    // ── Teams & admin ─────────────────────────────────────────────────────────
+    // Comma-separated emails with platform-wide admin access to /admin.
+    // Any authenticated user can also access /admin for teams they belong to.
+    "ADMIN_EMAILS": "",
+
+    // ── WakaTime (optional) ───────────────────────────────────────────────────
+    // If set, auto-writes ~/.wakatime.cfg in every container so users don't
+    // need to configure their API key manually.
+    // Get your key at wakatime.com/settings/account (or use a team API key).
+    "WAKATIME_API_KEY": "",
+
     // ── GitHub repo auto-cloning ──────────────────────────────────────────────
     // Comma-separated "owner/repo" pairs cloned into /workspace on container start.
     // Example: "myorg/frontend,myorg/api"
@@ -91,22 +113,22 @@
 
   // ── Secrets (set via CLI, never committed) ────────────────────────────────
   // Auth is handled by the Worker — code-server runs with --auth none.
-  // The container is only reachable through the authenticated Worker proxy.
   //
-  // R2 credentials for FUSE mount (geesefs inside the container):
+  // R2 credentials (FUSE mount inside container):
   //   wrangler secret put R2_ACCESS_KEY_ID
   //   wrangler secret put R2_SECRET_ACCESS_KEY
   //   wrangler secret put R2_ACCOUNT_ID
   //
-  // Google OAuth (if using auth option B):
+  // Google OAuth:
   //   wrangler secret put GOOGLE_CLIENT_SECRET
   //
-  // GitHub (if cloning private repos via GITHUB_REPOS):
+  // GitHub (private repos):
   //   wrangler secret put GITHUB_TOKEN
   //
   // Initial setup:
   //   wrangler login
   //   wrangler r2 bucket create vscode-cloud-workspaces
-  //   wrangler kv namespace create SESSION_STORE   # only if using Google OAuth
+  //   wrangler d1 create vscode-cloud-teams        # paste database_id above
+  //   wrangler kv namespace create SESSION_STORE   # paste id in kv_namespaces above
   //   wrangler deploy
 }

--- a/apps/vscode-cloud/wrangler.jsonc
+++ b/apps/vscode-cloud/wrangler.jsonc
@@ -6,6 +6,9 @@
   "compatibility_flags": ["nodejs_compat"],
 
   // ── Container definition ──────────────────────────────────────────────────
+  // FUSE (/dev/fuse) is available in Cloudflare Containers by default since 2025-11-21.
+  // Internet access is enabled at the class level via `enableInternet = true` so the
+  // container can reach the R2 S3-compat endpoint and github.com.
   "containers": [
     {
       "class_name": "CodeServerContainer",


### PR DESCRIPTION
## Summary

This PR adds a comprehensive team management system to the Cloud IDE platform, including a web dashboard for creating teams, inviting members, and viewing live container status. It also integrates WakaTime for time tracking and improves the landing page UX.

## Key Changes

### Team Management System
- **New `/admin` routes** for team CRUD operations:
  - `GET /admin` — dashboard showing teams the user belongs to (or all teams if platform admin)
  - `GET /admin/team/new` — form to create a new team
  - `POST /admin/team/create` — create team and add creator as admin
  - `GET /admin/team/:id` — team detail page with members table and invite management
  - `POST /admin/team/:id` — invite members, remove members, delete invites
  - `GET /admin/accept-invite` — accept invite link and join team

- **New `teams.ts` module** with D1 database schema and helpers:
  - `teams` table — team metadata (id, name, created_by, created_at)
  - `team_members` table — membership with roles (admin/member) and join dates
  - `team_invites` table — 7-day expiring invite tokens
  - Full CRUD operations for teams, members, and invites

- **Admin access control**:
  - Platform admins (via `ADMIN_EMAILS` env var) can see all teams
  - Regular users see only teams they belong to
  - Team admins can invite/remove members; members are read-only

### Live Container Status
- New `/__internal/state` RPC endpoint returns container status (running/stopped/sleeping)
- Team members table displays live status for each developer's container
- Status is fetched in parallel for performance

### WakaTime Integration
- `WAKATIME_API_KEY` env var auto-configures `~/.wakatime.cfg` in every container
- WakaTime extension pre-installed in Dockerfile
- Allows teams to track coding time per member

### UI Improvements
- **New landing page** with hero section, feature highlights, and auth options
- **Teams dashboard** with card grid layout showing team name, creation date, and manage link
- **Team detail page** with:
  - Members table (email, role, live status, join date, remove button)
  - Pending invites section with copy-to-clipboard invite URLs
  - Invite form to add new members by email
- **Consistent dark theme** matching GitHub's color palette

### Container & Deployment
- Updated `Dockerfile` to install Python 3, pip, and AI coding tools (Claude Code, Codex CLIs)
- Updated `entrypoint.sh` to configure WakaTime and improve VS Code settings
- Updated `wrangler.jsonc` with D1 database binding and configuration instructions
- Updated `Env` interface to include `TEAMS_DB`, `ADMIN_EMAILS`, and `WAKATIME_API_KEY`

### Auth & Security
- Invite tokens are cryptographically random UUIDs with 7-day expiration
- Team membership is validated on every admin action
- Platform admins bypass team membership checks
- Passwordless auth enforced at Worker layer (code-server runs with `--auth none`)

## Notable Implementation Details

- **HTML shell function** provides consistent nav/styling across all admin pages with dark theme
- **Helper functions** for HTML escaping, status badges, and container state queries
- **Parallel queries** for fetching members and their container statuses simultaneously
- **Idempotent invite creation** — same email can be invited multiple times, generating new tokens
- **Single-use invites** — token is deleted after acceptance
- **D1 schema auto-initialization** on first `/admin` request (no manual migrations needed)

https://claude.ai/code/session_01VSbGCNLi5Ydg8ViQijJEzG