### PR TITLE
Add D1 database and KV namespace IDs to wrangler config

### DIFF
--- a/apps/vscode-cloud/wrangler.jsonc
+++ b/apps/vscode-cloud/wrangler.jsonc
@@ -46,7 +46,7 @@
     {
       "binding": "TEAMS_DB",
       "database_name": "vscode-cloud-teams",
-      "database_id": "",  // paste the ID returned by `wrangler d1 create vscode-cloud-teams`
+      "database_id": "10349099-02ed-447b-b4a2-b096c4c04c5d",  // paste the ID returned by `wrangler d1 create vscode-cloud-teams`
     },
   ],
 
@@ -57,7 +57,7 @@
   "kv_namespaces": [
     {
       "binding": "SESSION_STORE",
-      "id": "",  // paste your KV namespace ID here after running the command above
+      "id": "b70d3fd540204ba0b92a34309ab4b94e",  // paste your KV namespace ID here after running the command above
     },
   ],
 


### PR DESCRIPTION
## Summary
Updated the wrangler.jsonc configuration file with the actual resource IDs for the D1 database and KV namespace used by the vscode-cloud application.

## Changes
- Added D1 database ID `10349099-02ed-447b-b4a2-b096c4c04c5d` for the `vscode-cloud-teams` database binding
- Added KV namespace ID `b70d3fd540204ba0b92a34309ab4b94e` for the `SESSION_STORE` binding

These IDs replace the previously empty placeholder values and enable the application to properly connect to the configured Cloudflare resources.

https://claude.ai/code/session_01CFzRyDMKWmqpFmfZ4ZN5VM