### PR TITLE
Enable Cloudflare Workers Observability in wrangler config

### DIFF
--- a/apps/vscode-cloud/wrangler.jsonc
+++ b/apps/vscode-cloud/wrangler.jsonc
@@ -111,6 +111,15 @@
     },
   ],
 
+  // ── Observability ─────────────────────────────────────────────────────────
+  // Enables Cloudflare Workers Observability: logs, traces, and metrics visible
+  // in the Cloudflare dashboard under Workers & Pages → your worker → Observability.
+  // head_sampling_rate: fraction of requests to trace (1 = 100%, 0.1 = 10%).
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
+
   // ── Secrets (set via CLI, never committed) ────────────────────────────────
   // Auth is handled by the Worker — code-server runs with --auth none.
   //


### PR DESCRIPTION
## Summary
Enable Cloudflare Workers Observability features for the VSCode Cloud worker by configuring logging, tracing, and metrics collection in the wrangler configuration.

## Key Changes
- Added `observability` configuration block to `wrangler.jsonc`
- Enabled observability with `enabled: true`
- Set `head_sampling_rate` to 1 (100% of requests) to capture all traces during development
- Added documentation comments explaining the observability feature and sampling rate configuration

## Implementation Details
The observability configuration enables visibility into worker behavior through:
- Logs, traces, and metrics that appear in the Cloudflare dashboard under Workers & Pages → your worker → Observability
- Head sampling rate set to 100% to ensure comprehensive tracing for development purposes (can be adjusted to lower values like 0.1 for 10% sampling in production)

https://claude.ai/code/session_01F7FARTYU45jdXkMm1H72Vp