### PR TITLE
feat(vscode-cloud): add Cloudflare Workers observability config

### DIFF
--- a/apps/vscode-cloud/wrangler.jsonc
+++ b/apps/vscode-cloud/wrangler.jsonc
@@ -111,6 +111,15 @@
     },
   ],
 
+  // ── Observability ─────────────────────────────────────────────────────────
+  // Enables Cloudflare Workers Observability: logs, traces, and metrics visible
+  // in the Cloudflare dashboard under Workers & Pages → your worker → Observability.
+  // head_sampling_rate: fraction of requests to trace (1 = 100%, 0.1 = 10%).
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+  },
+
   // ── Secrets (set via CLI, never committed) ────────────────────────────────
   // Auth is handled by the Worker — code-server runs with --auth none.
   //


### PR DESCRIPTION
Enables observability in wrangler.jsonc so logs, traces, and metrics are captured and visible in the Cloudflare dashboard under Workers & Pages → vscode-cloud → Observability. Sampling rate set to 100%.

https://claude.ai/code/session_01F7FARTYU45jdXkMm1H72Vp