### PR TITLE
Add Bun runtime to vscode-cloud Docker image

### DIFF
--- a/apps/vscode-cloud/Dockerfile
+++ b/apps/vscode-cloud/Dockerfile
@@ -75,6 +75,12 @@ RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
   && apt-get install -y --no-install-recommends nodejs \
   && rm -rf /var/lib/apt/lists/*
 
+# ── Bun ───────────────────────────────────────────────────────────────────────
+# Installed system-wide (BUN_INSTALL=/usr/local) so it's on PATH for every user,
+# same as the npm globals below via NPM_CONFIG_PREFIX.
+RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local bash \
+  && chmod -R a+rx /usr/local/bin/bun
+
 # ── Global npm tools ──────────────────────────────────────────────────────────
 # AI coding CLIs + TypeScript + language servers for VS Code IntelliSense
 ENV NPM_CONFIG_PREFIX=/usr/local


### PR DESCRIPTION
## Summary
This change adds Bun, a fast JavaScript runtime, to the vscode-cloud Docker image alongside the existing Node.js installation.

## Key Changes
- Install Bun system-wide at `/usr/local` to make it available on PATH for all users
- Configure Bun installation to match the same pattern as npm globals (via `NPM_CONFIG_PREFIX`)
- Set appropriate permissions (`chmod -R a+rx`) on the Bun binary to ensure accessibility

## Implementation Details
- Bun is installed using the official installation script from `https://bun.sh/install`
- The `BUN_INSTALL=/usr/local` environment variable directs the installer to place Bun in a system-wide location rather than the default user home directory
- This approach ensures Bun is available globally, consistent with how Node.js and npm tools are configured in the container

https://claude.ai/code/session_01TG2cCdrv6Bo9uUxBeyZivb