### PR TITLE
Fix package metadata and import paths in code-tree-graph

### DIFF
--- a/packages/code-tree-graph/components/code-tree/type-table.tsx
+++ b/packages/code-tree-graph/components/code-tree/type-table.tsx
@@ -14,7 +14,7 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-} from '../../ui/collapsible';
+} from '../ui/collapsible';
 
 export interface ParameterNode {
   name: string;

--- a/packages/code-tree-graph/package-lock.json
+++ b/packages/code-tree-graph/package-lock.json
@@ -23,7 +23,12 @@
         "typescript": "^5.9.3"
       },
       "devDependencies": {
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.2.14",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.3.4",
+        "react": "^19.2.4",
+        "react-dom": "^19.2.4",
         "vite": "^6.3.5",
         "vite-plugin-dts": "^4.5.4"
       },
@@ -2237,6 +2242,36 @@
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
     "node_modules/@types/trusted-types": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
@@ -2733,6 +2768,13 @@
       "dependencies": {
         "layout-base": "^1.0.0"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cytoscape": {
       "version": "3.34.0",
@@ -4091,6 +4133,29 @@
       ],
       "license": "MIT"
     },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -4227,6 +4292,13 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/semver": {
@@ -4410,6 +4482,13 @@
       "version": "1.6.4",
       "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/packages/code-tree-graph/package.json
+++ b/packages/code-tree-graph/package.json
@@ -2,14 +2,19 @@
   "name": "code-tree-graph",
   "version": "0.1.8",
   "description": "Code dependency graph and file tree visualization components",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OpenSourceAGI/starter-app-dev-tools/tree/master/packages/code-tree-graph"
+  },
+  "homepage": "https://github.com/OpenSourceAGI/starter-app-dev-tools/tree/master/packages/code-tree-graph",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     },
     "./dist/index.css": "./dist/index.css"
   },
@@ -36,7 +41,12 @@
     "typescript": "^5.9.3"
   },
   "devDependencies": {
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.4",
+    "react": "^19.2.4",
+    "react-dom": "^19.2.4",
     "vite": "^6.3.5",
     "vite-plugin-dts": "^4.5.4"
   },

--- a/packages/code-tree-graph/vite.config.ts
+++ b/packages/code-tree-graph/vite.config.ts
@@ -25,7 +25,8 @@ export default defineConfig({
         "react/jsx-runtime",
         "next",
         "next/navigation",
-        "fumadocs-core",
+        // match fumadocs-core and all of its subpath entries (e.g. fumadocs-core/link)
+        /^fumadocs-core(\/.*)?$/,
         // keep large server-only deps external so consumers can tree-shake or SSR them
         "@typescript-eslint/typescript-estree",
         "mermaid",


### PR DESCRIPTION
## Summary
This PR updates the code-tree-graph package configuration and fixes import path issues to improve package distribution and maintainability.

## Key Changes
- **Package metadata**: Added `repository` and `homepage` fields to package.json pointing to the GitHub repository
- **Export configuration**: Reordered the exports field to list `types` first, following best practices for TypeScript package exports
- **Dev dependencies**: Added missing type definitions (`@types/node`, `@types/react`, `@types/react-dom`) and React packages as dev dependencies
- **Vite configuration**: Updated the external dependencies regex for `fumadocs-core` to use a pattern that matches the package and all its subpath entries (e.g., `fumadocs-core/link`)
- **Import path fix**: Corrected relative import path in `type-table.tsx` from `../../ui/collapsible` to `../ui/collapsible` to match the actual directory structure

## Notable Details
The fumadocs-core external dependency change from a string to a regex pattern (`/^fumadocs-core(\/.*)?$/`) ensures that both the main package and any subpath imports are properly externalized during the build process, preventing bundling issues.

https://claude.ai/code/session_01KNjvnNcghG78Fuqczaxppi