### PR TITLE
Add live site link and browser usage information to docs

### DIFF
--- a/packages/api2ai-mcp-generator/README.md
+++ b/packages/api2ai-mcp-generator/README.md
@@ -3,6 +3,7 @@
     <img width="600px" src="https://i.imgur.com/TTJBLxo.png" />
 </p>
 <h3 align="center">
+  <a href="https://api-2-ai.vercel.app/"> 🌐 Live Site </a> &nbsp;|&nbsp;
   <a href="https://github.com/vtempest/GRAB-URL/tree/master/api2ai/example-petstore"> 🎯 Example MCP Server </a>
 </h3>
 
@@ -18,6 +19,8 @@
 Generate production-ready MCP servers from any OpenAPI specification using the highly-used and convenient [mcp-use](https://mcp-use.com) framework (8k+ GitHub stars).
 
 OpenAPI specs are easy to write and organize your code and have [100s of tools available](https://openapi.tools) such as the [OpenAPI Builder web UI](https://www.apibldr.com).
+
+Try it in the browser at **[api-2-ai.vercel.app](https://api-2-ai.vercel.app/)** — the hosted site lets you design and validate OpenAPI specs visually, browse the docs, and see generated-server examples without installing anything.
 
 ## Features
 

--- a/packages/api2ai-mcp-generator/content/docs/(index)/index.md
+++ b/packages/api2ai-mcp-generator/content/docs/(index)/index.md
@@ -7,6 +7,7 @@ icon: Bot
     <img width="600px" src="https://i.imgur.com/TTJBLxo.png" />
 </p>
 <h3 align="center">
+  <a href="https://api-2-ai.vercel.app/"> 🌐 Live Site </a> &nbsp;|&nbsp;
   <a href="https://github.com/vtempest/GRAB-URL/tree/master/api2ai/example-petstore"> 🎯 Example MCP Server </a>
 </h3>
 
@@ -22,6 +23,8 @@ icon: Bot
 Generate production-ready MCP servers from any OpenAPI specification using the highly-used and convenient [mcp-use](https://mcp-use.com) framework (8k+ GitHub stars).
 
 OpenAPI specs are easy to write and organize your code and have [100s of tools available](https://openapi.tools) such as the [OpenAPI Builder web UI](https://www.apibldr.com).
+
+Try it in the browser at **[api-2-ai.vercel.app](https://api-2-ai.vercel.app/)** — the hosted site lets you design and validate OpenAPI specs visually, browse the docs, and see generated-server examples without installing anything.
 
 ## Features
 


### PR DESCRIPTION
## Summary
Added promotional links and usage information for the hosted api-2-ai.verapp site to both the main README and documentation index page.

## Changes
- Added a "🌐 Live Site" link in the header navigation pointing to https://api-2-ai.vercel.app/
- Added a descriptive paragraph explaining that users can try the tool directly in the browser without installation, highlighting key features like visual OpenAPI spec design, documentation browsing, and generated server examples
- Updated both `packages/api2ai-mcp-generator/README.md` and `packages/api2ai-mcp-generator/content/docs/(index)/index.md` with consistent messaging

## Details
These changes make it easier for users to discover and access the hosted version of the tool, reducing friction for those who want to try the project without setting up a local development environment. The additions are placed prominently in the documentation to encourage browser-based exploration of the tool's capabilities.

https://claude.ai/code/session_01NkZGqPQVakiYZJNQnz8ry6